### PR TITLE
Fix window cropping, build docs, and hotkey modifier matching

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,44 @@ The old Config and Stats files will unfortunately not be compatible with the new
 
 ---
 
+## Building From Source
+
+This project is currently Windows-first. The maintained desktop build path is the Rust `x86_64-pc-windows-msvc` toolchain plus Node.js.
+
+Requirements:
+- Node.js 20 or newer
+- Rust via `rustup`
+- Microsoft C++ Build Tools / Visual Studio Build Tools
+
+Setup:
+```powershell
+git clone https://github.com/Blur009/Blur-AutoClicker.git
+cd Blur-AutoClicker
+npm install
+rustup default stable-x86_64-pc-windows-msvc
+```
+
+Run the app in development:
+```powershell
+npm exec tauri dev
+```
+
+Build a release bundle:
+```powershell
+npm exec tauri build
+```
+
+Useful validation commands:
+```powershell
+npm run lint
+npm run build
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+The built Windows installer is written to `src-tauri/target/release/bundle/nsis/`.
+
+---
+
 ## Support the project!
 [![ko-fi](https://www.ko-fi.com/img/donate_sm.png)](https://ko-fi.com/blur009)
 

--- a/src-tauri/src/hotkeys.rs
+++ b/src-tauri/src/hotkeys.rs
@@ -334,15 +334,36 @@ pub fn is_hotkey_binding_pressed(binding: &HotkeyBinding) -> bool {
     let shift_down = is_vk_down(VK_SHIFT as i32);
     let super_down = is_vk_down(VK_LWIN as i32) || is_vk_down(VK_RWIN as i32);
 
-    if ctrl_down != binding.ctrl
-        || alt_down != binding.alt
-        || shift_down != binding.shift
-        || super_down != binding.super_key
+    if !modifiers_match(binding, ctrl_down, alt_down, shift_down, super_down)
     {
         return false;
     }
 
     is_main_key_active(binding.main_vk)
+}
+
+fn modifiers_match(
+    binding: &HotkeyBinding,
+    ctrl_down: bool,
+    alt_down: bool,
+    shift_down: bool,
+    super_down: bool,
+) -> bool {
+    if binding.ctrl && !ctrl_down {
+        return false;
+    }
+    if binding.alt && !alt_down {
+        return false;
+    }
+    if binding.shift && !shift_down {
+        return false;
+    }
+    if binding.super_key && !super_down
+    {
+        return false;
+    }
+
+    true
 }
 
 /// For normal VKs this uses `GetAsyncKeyState`. Pseudo-VKs use hook-maintained state.
@@ -442,7 +463,7 @@ unsafe extern "system" fn mouse_hook_proc(code: i32, w_param: usize, l_param: is
 
 #[cfg(test)]
 mod tests {
-    use super::{format_hotkey_binding, parse_hotkey_binding};
+    use super::{format_hotkey_binding, modifiers_match, parse_hotkey_binding};
 
     #[test]
     fn numpad_tokens_round_trip() {
@@ -475,5 +496,12 @@ mod tests {
     fn empty_hotkeys_are_rejected() {
         assert!(parse_hotkey_binding("").is_err());
         assert!(parse_hotkey_binding("ctrl+").is_err());
+    }
+
+    #[test]
+    fn extra_modifiers_do_not_block_hotkeys() {
+        let binding = parse_hotkey_binding("f11").expect("hotkey should parse");
+        assert!(modifiers_match(&binding, false, false, true, false));
+        assert!(modifiers_match(&binding, true, true, true, true));
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+import {
+  currentMonitor,
+  getCurrentWindow,
+  LogicalSize,
+} from "@tauri-apps/api/window";
 import { lazy, useEffect, useRef, useState } from "react";
 import UpdateBanner from "./components/Updatebanner";
 import { canonicalizeHotkeyForBackend } from "./hotkeys";
@@ -34,6 +38,24 @@ function getPanelSize(tab: Tab, settings: Settings, hasUpdate: boolean) {
   return settings.explanationMode === "off"
     ? { width: 600, height: 600 + extra }
     : { width: 800, height: 650 + extra };
+}
+
+async function getClampedPanelSize(size: { width: number; height: number }) {
+  const monitor = await currentMonitor();
+  if (!monitor) {
+    return size;
+  }
+
+  const scale = monitor.scaleFactor || 1;
+  const workAreaWidth = Math.floor(monitor.workArea.size.width / scale);
+  const workAreaHeight = Math.floor(monitor.workArea.size.height / scale);
+  const horizontalMargin = 24;
+  const verticalMargin = 24;
+
+  return {
+    width: Math.min(size.width, Math.max(360, workAreaWidth - horizontalMargin)),
+    height: Math.min(size.height, Math.max(220, workAreaHeight - verticalMargin)),
+  };
 }
 
 const DEFAULT_STATUS: ClickerStatus = {
@@ -284,11 +306,13 @@ export default function App() {
       resizeTimeout.current = null;
     }
 
-    const { width, height } = getPanelSize(tab, settings, !!updateInfo);
+    const preferredSize = getPanelSize(tab, settings, !!updateInfo);
     const root = document.querySelector(".app-root") as HTMLElement;
 
     void (async () => {
       try {
+        const { width, height } = await getClampedPanelSize(preferredSize);
+
         if (!launchWindowPlacementDone.current) {
           const appWindow = getCurrentWindow();
           await appWindow.setSize(new LogicalSize(width, height));

--- a/src/components/panels/SimplePanel.css
+++ b/src/components/panels/SimplePanel.css
@@ -5,7 +5,8 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100%;
+  min-height: 0;
   gap: 8px;
 
 }

--- a/src/index.css
+++ b/src/index.css
@@ -91,14 +91,16 @@ body {
 .app-root {
   border: 1px var(--border-subtle) solid;
   background: var(--bg-base);
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   border-radius: var(--radius-md);
   transition: height 0.2s cubic-bezier(0.4, 0, 0.2, 1), width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
+  min-width: 0;
+  min-height: 0;
 }
 
 .panel-area {
@@ -106,5 +108,7 @@ body {
   padding: 20px 20px 20px 20px;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: auto;
+  min-height: 0;
+  min-width: 0;
 }


### PR DESCRIPTION
## Summary
- add source build instructions for the current Windows/MSVC setup
- clamp the app window to the active monitor work area so oversized layouts do not get cropped off-screen
- let the main panel scroll instead of hiding overflow when the available window space is smaller than the preferred layout
- fix hotkey matching so extra held modifiers no longer block a valid hotkey

## Fixes
- fixes #6
- fixes #24
- fixes #31
- fixes #37
- fixes #46

## Validation
- `npm run lint`
- `npm run build`
- `cargo test`
- `npm exec tauri build`

## Notes
- the Tauri build completed through NSIS bundling successfully
- the final signing step still requires `TAURI_SIGNING_PRIVATE_KEY` in the environment
