### PR TITLE
Add robust mouse-button and numpad hotkey support

### DIFF
--- a/src-tauri/src/hotkeys.rs
+++ b/src-tauri/src/hotkeys.rs
@@ -4,27 +4,10 @@ use crate::engine::worker::stop_clicker_inner;
 use crate::engine::worker::toggle_clicker_inner;
 use crate::AppHandle;
 use crate::ClickerState;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tauri::Manager;
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::*;
-use windows_sys::Win32::UI::WindowsAndMessaging::{
-    CallNextHookEx, GetMessageW, SetWindowsHookExW, KBDLLHOOKSTRUCT, LLKHF_EXTENDED, MSG,
-    WH_KEYBOARD_LL, WH_MOUSE_LL, WM_KEYDOWN, WM_KEYUP, WM_MOUSEWHEEL, WM_SYSKEYDOWN, WM_SYSKEYUP,
-};
-
-/// Pseudo virtual-key codes for inputs that do not have a stable VK we can poll.
-pub const VK_SCROLL_UP_PSEUDO: i32 = -1;
-pub const VK_SCROLL_DOWN_PSEUDO: i32 = -2;
-pub const VK_NUMPAD_ENTER_PSEUDO: i32 = -3;
-
-/// Epoch-ms timestamps of the last detected scroll events.
-static SCROLL_UP_AT: AtomicU64 = AtomicU64::new(0);
-static SCROLL_DOWN_AT: AtomicU64 = AtomicU64::new(0);
-static NUMPAD_ENTER_DOWN: AtomicBool = AtomicBool::new(false);
-
-/// How long a scroll event is considered "pressed" for the polling loop.
-const SCROLL_WINDOW_MS: u64 = 200;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HotkeyBinding {
@@ -51,13 +34,7 @@ pub fn register_hotkey_inner(app: &AppHandle, hotkey: String) -> Result<String, 
 }
 
 pub fn normalize_hotkey(value: &str) -> String {
-    value
-        .trim()
-        .to_lowercase()
-        .replace("control", "ctrl")
-        .replace("command", "super")
-        .replace("meta", "super")
-        .replace("win", "super")
+    value.trim().to_ascii_lowercase()
 }
 
 pub fn parse_hotkey_binding(hotkey: &str) -> Result<HotkeyBinding, String> {
@@ -73,12 +50,13 @@ pub fn parse_hotkey_binding(hotkey: &str) -> Result<HotkeyBinding, String> {
             return Err(format!("Invalid hotkey '{hotkey}': found empty key token"));
         }
 
-        match token {
-            "alt" | "option" => alt = true,
-            "ctrl" | "control" => ctrl = true,
-            "shift" => shift = true,
-            "super" | "command" | "cmd" | "meta" | "win" => super_key = true,
-            _ => {
+        match normalize_modifier_token(token) {
+            Some("ctrl") => ctrl = true,
+            Some("alt") => alt = true,
+            Some("shift") => shift = true,
+            Some("super") => super_key = true,
+            Some(_) => {}
+            None => {
                 if main_key
                     .replace(parse_hotkey_main_key(token, hotkey)?)
                     .is_some()
@@ -105,86 +83,22 @@ pub fn parse_hotkey_binding(hotkey: &str) -> Result<HotkeyBinding, String> {
 }
 
 pub fn parse_hotkey_main_key(token: &str, original_hotkey: &str) -> Result<(i32, String), String> {
-    let lower = token.trim().to_lowercase();
+    let lower = token.trim().to_ascii_lowercase();
 
-    let mapped = match lower.as_str() {
-        // Mouse buttons
-        "mouseleft" | "mouse1" => Some((VK_LBUTTON as i32, String::from("mouseleft"))),
-        "mouseright" | "mouse2" => Some((VK_RBUTTON as i32, String::from("mouseright"))),
-        "mousemiddle" | "mouse3" | "scrollbutton" | "middleclick" => {
-            Some((VK_MBUTTON as i32, String::from("mousemiddle")))
-        }
-        "mouse4" | "mouseback" | "xbutton1" => Some((VK_XBUTTON1 as i32, String::from("mouse4"))),
-        "mouse5" | "mouseforward" | "xbutton2" => {
-            Some((VK_XBUTTON2 as i32, String::from("mouse5")))
-        }
-        // Scroll wheel
-        "scrollup" | "wheelup" => Some((VK_SCROLL_UP_PSEUDO, String::from("scrollup"))),
-        "scrolldown" | "wheeldown" => Some((VK_SCROLL_DOWN_PSEUDO, String::from("scrolldown"))),
-        // Explicit numpad keys
-        "numpad0" => Some((VK_NUMPAD0 as i32, String::from("numpad0"))),
-        "numpad1" => Some((VK_NUMPAD1 as i32, String::from("numpad1"))),
-        "numpad2" => Some((VK_NUMPAD2 as i32, String::from("numpad2"))),
-        "numpad3" => Some((VK_NUMPAD3 as i32, String::from("numpad3"))),
-        "numpad4" => Some((VK_NUMPAD4 as i32, String::from("numpad4"))),
-        "numpad5" => Some((VK_NUMPAD5 as i32, String::from("numpad5"))),
-        "numpad6" => Some((VK_NUMPAD6 as i32, String::from("numpad6"))),
-        "numpad7" => Some((VK_NUMPAD7 as i32, String::from("numpad7"))),
-        "numpad8" => Some((VK_NUMPAD8 as i32, String::from("numpad8"))),
-        "numpad9" => Some((VK_NUMPAD9 as i32, String::from("numpad9"))),
-        "numpadadd" => Some((VK_ADD as i32, String::from("numpadadd"))),
-        "numpadsubtract" => Some((VK_SUBTRACT as i32, String::from("numpadsubtract"))),
-        "numpadmultiply" => Some((VK_MULTIPLY as i32, String::from("numpadmultiply"))),
-        "numpaddivide" => Some((VK_DIVIDE as i32, String::from("numpaddivide"))),
-        "numpaddecimal" => Some((VK_DECIMAL as i32, String::from("numpaddecimal"))),
-        "numpadenter" => Some((VK_NUMPAD_ENTER_PSEUDO, String::from("numpadenter"))),
-        // Keyboard keys
-        "<" | ">" | "intlbackslash" | "oem102" | "nonusbackslash" => {
-            Some((VK_OEM_102 as i32, String::from("IntlBackslash")))
-        }
-        "space" | "spacebar" => Some((VK_SPACE as i32, String::from("space"))),
-        "tab" => Some((VK_TAB as i32, String::from("tab"))),
-        "enter" => Some((VK_RETURN as i32, String::from("enter"))),
-        "backspace" => Some((VK_BACK as i32, String::from("backspace"))),
-        "delete" => Some((VK_DELETE as i32, String::from("delete"))),
-        "insert" => Some((VK_INSERT as i32, String::from("insert"))),
-        "home" => Some((VK_HOME as i32, String::from("home"))),
-        "end" => Some((VK_END as i32, String::from("end"))),
-        "pageup" => Some((VK_PRIOR as i32, String::from("pageup"))),
-        "pagedown" => Some((VK_NEXT as i32, String::from("pagedown"))),
-        "up" => Some((VK_UP as i32, String::from("up"))),
-        "down" => Some((VK_DOWN as i32, String::from("down"))),
-        "left" => Some((VK_LEFT as i32, String::from("left"))),
-        "right" => Some((VK_RIGHT as i32, String::from("right"))),
-        "esc" | "escape" => Some((VK_ESCAPE as i32, String::from("escape"))),
-        "/" | "slash" => Some((VK_OEM_2 as i32, String::from("/"))),
-        "\\" | "backslash" => Some((VK_OEM_5 as i32, String::from("\\"))),
-        ";" | "semicolon" => Some((VK_OEM_1 as i32, String::from(";"))),
-        "'" | "quote" => Some((VK_OEM_7 as i32, String::from("'"))),
-        "[" | "bracketleft" => Some((VK_OEM_4 as i32, String::from("["))),
-        "]" | "bracketright" => Some((VK_OEM_6 as i32, String::from("]"))),
-        "-" | "minus" => Some((VK_OEM_MINUS as i32, String::from("-"))),
-        "=" | "equal" => Some((VK_OEM_PLUS as i32, String::from("="))),
-        "`" | "backquote" => Some((VK_OEM_3 as i32, String::from("`"))),
-        "," | "comma" => Some((VK_OEM_COMMA as i32, String::from(","))),
-        "." | "period" => Some((VK_OEM_PERIOD as i32, String::from("."))),
-        _ => None,
-    };
-
-    if let Some(binding) = mapped {
+    if let Some(binding) = parse_named_key_token(&lower) {
         return Ok(binding);
     }
 
-    if lower.starts_with('f') && lower.len() <= 3 {
-        if let Ok(number) = lower[1..].parse::<i32>() {
-            let vk = match number {
-                1..=24 => VK_F1 as i32 + (number - 1),
-                _ => -1,
-            };
-            if vk >= 0 {
-                return Ok((vk, lower));
-            }
-        }
+    if let Some(binding) = parse_mouse_button_token(&lower) {
+        return Ok(binding);
+    }
+
+    if let Some(binding) = parse_numpad_token(&lower) {
+        return Ok(binding);
+    }
+
+    if let Some(binding) = parse_function_key_token(&lower) {
+        return Ok(binding);
     }
 
     if let Some(letter) = lower.strip_prefix("key") {
@@ -248,7 +162,7 @@ pub fn start_hotkey_listener(app: AppHandle) {
 
             let currently_pressed = binding
                 .as_ref()
-                .map(|b| is_hotkey_binding_pressed(b, strict))
+                .map(|binding| is_hotkey_binding_pressed(binding, strict))
                 .unwrap_or(false);
 
             let suppress_until = app
@@ -339,7 +253,7 @@ pub fn is_hotkey_binding_pressed(binding: &HotkeyBinding, strict: bool) -> bool 
         return false;
     }
 
-    is_main_key_active(binding.main_vk)
+    is_vk_down(binding.main_vk)
 }
 
 fn modifiers_match(
@@ -364,108 +278,150 @@ fn modifiers_match(
     }
 
     if strict {
-        if ctrl_down && !binding.ctrl { return false; }
-        if alt_down && !binding.alt { return false; }
-        if shift_down && !binding.shift { return false; }
-        if super_down && !binding.super_key { return false; }
+        if ctrl_down && !binding.ctrl {
+            return false;
+        }
+        if alt_down && !binding.alt {
+            return false;
+        }
+        if shift_down && !binding.shift {
+            return false;
+        }
+        if super_down && !binding.super_key {
+            return false;
+        }
     }
 
     true
-}
-
-/// For normal VKs this uses `GetAsyncKeyState`. Pseudo-VKs use hook-maintained state.
-fn is_main_key_active(vk: i32) -> bool {
-    match vk {
-        VK_SCROLL_UP_PSEUDO => {
-            let ts = SCROLL_UP_AT.load(Ordering::SeqCst);
-            if ts == 0 {
-                return false;
-            }
-            let now = now_epoch_ms();
-            now.saturating_sub(ts) < SCROLL_WINDOW_MS
-        }
-        VK_SCROLL_DOWN_PSEUDO => {
-            let ts = SCROLL_DOWN_AT.load(Ordering::SeqCst);
-            if ts == 0 {
-                return false;
-            }
-            let now = now_epoch_ms();
-            now.saturating_sub(ts) < SCROLL_WINDOW_MS
-        }
-        VK_NUMPAD_ENTER_PSEUDO => NUMPAD_ENTER_DOWN.load(Ordering::SeqCst),
-        _ => is_vk_down(vk),
-    }
 }
 
 pub fn is_vk_down(vk: i32) -> bool {
     unsafe { (GetAsyncKeyState(vk) as u16 & 0x8000) != 0 }
 }
 
-/// Installs low-level hooks used for scroll and numpad-enter hotkeys.
-pub fn start_scroll_hook() {
-    std::thread::spawn(|| unsafe {
-        let mouse_hook = SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_hook_proc), 0, 0);
-        if mouse_hook == 0 {
-            log::error!("[Hotkeys] Failed to install WH_MOUSE_LL hook");
-        }
-
-        let keyboard_hook = SetWindowsHookExW(WH_KEYBOARD_LL, Some(keyboard_hook_proc), 0, 0);
-        if keyboard_hook == 0 {
-            log::error!("[Hotkeys] Failed to install WH_KEYBOARD_LL hook");
-        }
-
-        if mouse_hook == 0 && keyboard_hook == 0 {
-            return;
-        }
-
-        let mut msg: MSG = std::mem::zeroed();
-        while GetMessageW(&mut msg, 0, 0, 0) > 0 {}
-    });
+fn normalize_modifier_token(token: &str) -> Option<&'static str> {
+    match token {
+        "alt" | "option" => Some("alt"),
+        "ctrl" | "control" => Some("ctrl"),
+        "shift" => Some("shift"),
+        "super" | "command" | "cmd" | "meta" | "win" => Some("super"),
+        _ => None,
+    }
 }
 
-unsafe extern "system" fn keyboard_hook_proc(code: i32, w_param: usize, l_param: isize) -> isize {
-    if code >= 0 {
-        let info = &*(l_param as *const KBDLLHOOKSTRUCT);
-        if info.vkCode as i32 == VK_RETURN as i32 && (info.flags & LLKHF_EXTENDED) != 0 {
-            match w_param as u32 {
-                WM_KEYDOWN | WM_SYSKEYDOWN => {
-                    NUMPAD_ENTER_DOWN.store(true, Ordering::SeqCst);
-                }
-                WM_KEYUP | WM_SYSKEYUP => {
-                    NUMPAD_ENTER_DOWN.store(false, Ordering::SeqCst);
-                }
-                _ => {}
-            }
-        }
-    }
-
-    CallNextHookEx(0, code, w_param, l_param)
+fn binding(vk: i32, token: &str) -> (i32, String) {
+    (vk, token.to_string())
 }
 
-/// Raw low-level mouse-hook callback. We only care about `WM_MOUSEWHEEL`.
-unsafe extern "system" fn mouse_hook_proc(code: i32, w_param: usize, l_param: isize) -> isize {
-    if code >= 0 && w_param == WM_MOUSEWHEEL as usize {
-        #[repr(C)]
-        struct MsllHookStruct {
-            pt_x: i32,
-            pt_y: i32,
-            mouse_data: u32,
-            flags: u32,
-            time: u32,
-            extra_info: usize,
+fn parse_named_key_token(token: &str) -> Option<(i32, String)> {
+    match token {
+        "<" | ">" | "intlbackslash" | "oem102" | "nonusbackslash" => {
+            Some(binding(VK_OEM_102 as i32, "IntlBackslash"))
         }
+        "space" | "spacebar" => Some(binding(VK_SPACE as i32, "space")),
+        "tab" => Some(binding(VK_TAB as i32, "tab")),
+        "enter" | "return" => Some(binding(VK_RETURN as i32, "enter")),
+        "backspace" => Some(binding(VK_BACK as i32, "backspace")),
+        "delete" | "del" => Some(binding(VK_DELETE as i32, "delete")),
+        "insert" | "ins" => Some(binding(VK_INSERT as i32, "insert")),
+        "home" => Some(binding(VK_HOME as i32, "home")),
+        "end" => Some(binding(VK_END as i32, "end")),
+        "pageup" | "pgup" => Some(binding(VK_PRIOR as i32, "pageup")),
+        "pagedown" | "pgdn" => Some(binding(VK_NEXT as i32, "pagedown")),
+        "up" | "arrowup" => Some(binding(VK_UP as i32, "up")),
+        "down" | "arrowdown" => Some(binding(VK_DOWN as i32, "down")),
+        "left" | "arrowleft" => Some(binding(VK_LEFT as i32, "left")),
+        "right" | "arrowright" => Some(binding(VK_RIGHT as i32, "right")),
+        "esc" | "escape" => Some(binding(VK_ESCAPE as i32, "escape")),
+        "capslock" => Some(binding(VK_CAPITAL as i32, "capslock")),
+        "numlock" => Some(binding(VK_NUMLOCK as i32, "numlock")),
+        "scrolllock" => Some(binding(VK_SCROLL as i32, "scrolllock")),
+        "menu" | "apps" | "contextmenu" => Some(binding(VK_APPS as i32, "menu")),
+        "printscreen" | "prtsc" | "snapshot" => Some(binding(VK_SNAPSHOT as i32, "printscreen")),
+        "pause" | "break" => Some(binding(VK_PAUSE as i32, "pause")),
+        "/" | "slash" => Some(binding(VK_OEM_2 as i32, "/")),
+        "\\" | "backslash" => Some(binding(VK_OEM_5 as i32, "\\")),
+        ";" | "semicolon" => Some(binding(VK_OEM_1 as i32, ";")),
+        "'" | "quote" | "apostrophe" => Some(binding(VK_OEM_7 as i32, "'")),
+        "[" | "bracketleft" => Some(binding(VK_OEM_4 as i32, "[")),
+        "]" | "bracketright" => Some(binding(VK_OEM_6 as i32, "]")),
+        "-" | "minus" => Some(binding(VK_OEM_MINUS as i32, "-")),
+        "=" | "equal" => Some(binding(VK_OEM_PLUS as i32, "=")),
+        "`" | "backquote" | "grave" => Some(binding(VK_OEM_3 as i32, "`")),
+        "," | "comma" => Some(binding(VK_OEM_COMMA as i32, ",")),
+        "." | "period" | "dot" => Some(binding(VK_OEM_PERIOD as i32, ".")),
+        _ => None,
+    }
+}
 
-        let info = &*(l_param as *const MsllHookStruct);
-        let delta = (info.mouse_data >> 16) as i16;
-        let now = now_epoch_ms();
-        if delta > 0 {
-            SCROLL_UP_AT.store(now, Ordering::SeqCst);
-        } else if delta < 0 {
-            SCROLL_DOWN_AT.store(now, Ordering::SeqCst);
+fn parse_mouse_button_token(token: &str) -> Option<(i32, String)> {
+    match token {
+        "mouseleft" | "leftmouse" | "leftbutton" | "mouse1" | "lmb" => {
+            Some(binding(VK_LBUTTON as i32, "mouseleft"))
         }
+        "mouseright" | "rightmouse" | "rightbutton" | "mouse2" | "rmb" => {
+            Some(binding(VK_RBUTTON as i32, "mouseright"))
+        }
+        "mousemiddle"
+        | "middlemouse"
+        | "middlebutton"
+        | "mouse3"
+        | "mmb"
+        | "scrollbutton"
+        | "middleclick" => Some(binding(VK_MBUTTON as i32, "mousemiddle")),
+        "mouse4" | "xbutton1" | "mouseback" | "browserback" | "backbutton" => {
+            Some(binding(VK_XBUTTON1 as i32, "mouse4"))
+        }
+        "mouse5" | "xbutton2" | "mouseforward" | "browserforward" | "forwardbutton" => {
+            Some(binding(VK_XBUTTON2 as i32, "mouse5"))
+        }
+        _ => None,
+    }
+}
+
+fn parse_numpad_token(token: &str) -> Option<(i32, String)> {
+    match token {
+        "numpad0" | "num0" => Some(binding(VK_NUMPAD0 as i32, "numpad0")),
+        "numpad1" | "num1" => Some(binding(VK_NUMPAD1 as i32, "numpad1")),
+        "numpad2" | "num2" => Some(binding(VK_NUMPAD2 as i32, "numpad2")),
+        "numpad3" | "num3" => Some(binding(VK_NUMPAD3 as i32, "numpad3")),
+        "numpad4" | "num4" => Some(binding(VK_NUMPAD4 as i32, "numpad4")),
+        "numpad5" | "num5" => Some(binding(VK_NUMPAD5 as i32, "numpad5")),
+        "numpad6" | "num6" => Some(binding(VK_NUMPAD6 as i32, "numpad6")),
+        "numpad7" | "num7" => Some(binding(VK_NUMPAD7 as i32, "numpad7")),
+        "numpad8" | "num8" => Some(binding(VK_NUMPAD8 as i32, "numpad8")),
+        "numpad9" | "num9" => Some(binding(VK_NUMPAD9 as i32, "numpad9")),
+        "numpadadd" | "numadd" | "numpadplus" | "numplus" => {
+            Some(binding(VK_ADD as i32, "numpadadd"))
+        }
+        "numpadsubtract" | "numsubtract" | "numsub" | "numpadminus" | "numminus" => {
+            Some(binding(VK_SUBTRACT as i32, "numpadsubtract"))
+        }
+        "numpadmultiply" | "nummultiply" | "nummul" | "numpadmul" => {
+            Some(binding(VK_MULTIPLY as i32, "numpadmultiply"))
+        }
+        "numpaddivide" | "numdivide" | "numdiv" | "numpaddiv" => {
+            Some(binding(VK_DIVIDE as i32, "numpaddivide"))
+        }
+        "numpaddecimal" | "numdecimal" | "numdot" | "numdel" | "numpadpoint" => {
+            Some(binding(VK_DECIMAL as i32, "numpaddecimal"))
+        }
+        _ => None,
+    }
+}
+
+fn parse_function_key_token(token: &str) -> Option<(i32, String)> {
+    if !token.starts_with('f') || token.len() > 3 {
+        return None;
     }
 
-    CallNextHookEx(0, code, w_param, l_param)
+    let number = token[1..].parse::<i32>().ok()?;
+    let vk = match number {
+        1..=24 => VK_F1 as i32 + (number - 1),
+        _ => return None,
+    };
+
+    Some(binding(vk, token))
 }
 
 #[cfg(test)]
@@ -490,7 +446,6 @@ mod tests {
             "numpadmultiply",
             "numpaddivide",
             "numpaddecimal",
-            "numpadenter",
         ] {
             let hotkey = format!("ctrl+shift+{token}");
             let binding = parse_hotkey_binding(&hotkey).expect("token should parse");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,7 +83,6 @@ pub fn run() {
 
             let handle = app.handle().clone();
             start_hotkey_listener(handle.clone());
-            hotkeys::start_scroll_hook();
             register_hotkey_inner(&handle, initial_hotkey).map_err(std::io::Error::other)?;
             emit_status(&handle);
             overlay::init_overlay(app.handle())?;

--- a/src/components/HotkeyCaptureInput.tsx
+++ b/src/components/HotkeyCaptureInput.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
   captureHotkey,
   captureMouseHotkey,
-  captureWheelHotkey,
   formatHotkeyForDisplay,
   getKeyboardLayoutMap,
 } from "../hotkeys";
@@ -22,6 +21,10 @@ export default function HotkeyCaptureInput({
   style,
 }: Props) {
   const [listening, setListening] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const ignorePrimaryInputMouseUntilRef = useRef(0);
+  const suppressedMouseButtonRef = useRef<number | null>(null);
+  const suppressResetTimerRef = useRef<number | null>(null);
   const [layoutMap, setLayoutMap] =
     useState<Awaited<ReturnType<typeof getKeyboardLayoutMap>>>(null);
 
@@ -40,6 +43,14 @@ export default function HotkeyCaptureInput({
   }, []);
 
   useEffect(() => {
+    return () => {
+      if (suppressResetTimerRef.current !== null) {
+        window.clearTimeout(suppressResetTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     invoke("set_hotkey_capture_active", { active: listening }).catch((err) => {
       console.error("Failed to toggle hotkey capture state:", err);
     });
@@ -53,103 +64,137 @@ export default function HotkeyCaptureInput({
     };
   }, [listening]);
 
+  useEffect(() => {
+    const handleSuppressedMouseEvent = (event: MouseEvent) => {
+      if (suppressedMouseButtonRef.current !== event.button) return;
+
+      if (event.cancelable) {
+        event.preventDefault();
+      }
+      event.stopPropagation();
+    };
+
+    window.addEventListener("mouseup", handleSuppressedMouseEvent, true);
+    window.addEventListener("click", handleSuppressedMouseEvent, true);
+    window.addEventListener("auxclick", handleSuppressedMouseEvent, true);
+    window.addEventListener("contextmenu", handleSuppressedMouseEvent, true);
+
+    return () => {
+      window.removeEventListener("mouseup", handleSuppressedMouseEvent, true);
+      window.removeEventListener("click", handleSuppressedMouseEvent, true);
+      window.removeEventListener("auxclick", handleSuppressedMouseEvent, true);
+      window.removeEventListener("contextmenu", handleSuppressedMouseEvent, true);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!listening) return;
+
+    const finishCapture = (nextHotkey?: string) => {
+      if (nextHotkey !== undefined) {
+        onChange(nextHotkey);
+      }
+      setListening(false);
+      inputRef.current?.blur();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (event.key === "Escape") {
+        finishCapture();
+        return;
+      }
+
+      if (
+        (event.key === "Backspace" || event.key === "Delete") &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        !event.metaKey
+      ) {
+        finishCapture("");
+        return;
+      }
+
+      const nextHotkey = captureHotkey(event);
+      if (!nextHotkey) return;
+
+      finishCapture(nextHotkey);
+    };
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const input = inputRef.current;
+      const isInputTarget =
+        input !== null &&
+        event.target instanceof Node &&
+        input.contains(event.target);
+
+      if (
+        isInputTarget &&
+        event.button === 0 &&
+        performance.now() < ignorePrimaryInputMouseUntilRef.current
+      ) {
+        return;
+      }
+
+      const nextHotkey = captureMouseHotkey(event);
+      if (!nextHotkey) return;
+
+      suppressedMouseButtonRef.current = event.button;
+      if (suppressResetTimerRef.current !== null) {
+        window.clearTimeout(suppressResetTimerRef.current);
+      }
+      suppressResetTimerRef.current = window.setTimeout(() => {
+        suppressedMouseButtonRef.current = null;
+        suppressResetTimerRef.current = null;
+      }, 200);
+
+      if (event.cancelable) {
+        event.preventDefault();
+      }
+      event.stopPropagation();
+
+      finishCapture(nextHotkey);
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    window.addEventListener("mousedown", handleMouseDown, true);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+      window.removeEventListener("mousedown", handleMouseDown, true);
+    };
+  }, [listening, onChange]);
+
   const displayText = useMemo(
     () =>
-      listening ? "Press keys..." : formatHotkeyForDisplay(value, layoutMap),
+      listening
+        ? "Press key / mouse..."
+        : formatHotkeyForDisplay(value, layoutMap),
     [layoutMap, listening, value],
   );
 
-  const acceptHotkey = (
-    nextHotkey: string | null,
-    target: HTMLInputElement,
-  ) => {
-    if (!nextHotkey) return;
-    onChange(nextHotkey);
-    setListening(false);
-    target.blur();
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    if (event.key === "Escape") {
-      setListening(false);
-      event.currentTarget.blur();
-      return;
-    }
-
-    if (
-      (event.key === "Backspace" || event.key === "Delete") &&
-      !event.ctrlKey &&
-      !event.altKey &&
-      !event.shiftKey &&
-      !event.metaKey
-    ) {
-      onChange("");
-      setListening(false);
-      event.currentTarget.blur();
-      return;
-    }
-
-    acceptHotkey(
-      captureHotkey({
-        key: event.key,
-        code: event.code,
-        location: event.location,
-        ctrlKey: event.ctrlKey,
-        altKey: event.altKey,
-        shiftKey: event.shiftKey,
-        metaKey: event.metaKey,
-      }),
-      event.currentTarget,
-    );
-  };
-
-  const handleMouseDown = (event: React.MouseEvent<HTMLInputElement>) => {
-    // Left click (button 0) is used to start listening — don't capture it
-    // if no modifier is present.
-    if (!listening) return;
-
-    if (event.button === 0) {
-      const hasModifier =
-        event.ctrlKey || event.altKey || event.shiftKey || event.metaKey;
-      if (!hasModifier) return;
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-    acceptHotkey(captureMouseHotkey(event), event.currentTarget);
-  };
-
-  const handleWheel = (event: React.WheelEvent<HTMLInputElement>) => {
-    if (!listening) return;
-
-    event.preventDefault();
-    event.stopPropagation();
-    acceptHotkey(captureWheelHotkey(event), event.currentTarget);
-  };
-
-  const handleContextMenu = (event: React.MouseEvent<HTMLInputElement>) => {
-    // Prevent context menu when listening so right-click can be captured
-    if (listening) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
-  };
-
   return (
     <input
+      ref={inputRef}
       type="text"
       className={className}
       value={displayText}
       readOnly
+      onMouseDown={(event) => {
+        if (event.button === 0) {
+          ignorePrimaryInputMouseUntilRef.current = performance.now() + 150;
+        }
+      }}
       onFocus={() => setListening(true)}
       onBlur={() => setListening(false)}
-      onKeyDown={handleKeyDown}
-      onMouseDown={handleMouseDown}
-      onWheel={handleWheel}
-      onContextMenu={handleContextMenu}
+      onContextMenu={(event) => {
+        if (listening) {
+          event.preventDefault();
+        }
+      }}
       spellCheck={false}
       style={style}
     />

--- a/src/hotkeys.ts
+++ b/src/hotkeys.ts
@@ -21,6 +21,19 @@ const MODIFIER_KEYS = new Set([
   "altgraph",
 ]);
 
+const MODIFIER_CODES = new Set([
+  "ControlLeft",
+  "ControlRight",
+  "ShiftLeft",
+  "ShiftRight",
+  "AltLeft",
+  "AltRight",
+  "MetaLeft",
+  "MetaRight",
+  "OSLeft",
+  "OSRight",
+]);
+
 const SHIFTED_SYMBOL_BASE_MAP: Record<string, string> = {
   "?": "/",
   ":": ";",
@@ -34,23 +47,33 @@ const SHIFTED_SYMBOL_BASE_MAP: Record<string, string> = {
   ">": "<",
 };
 
-const NUMPAD_CODE_MAP: Record<string, string> = {
-  Numpad0: "numpad0",
-  Numpad1: "numpad1",
-  Numpad2: "numpad2",
-  Numpad3: "numpad3",
-  Numpad4: "numpad4",
-  Numpad5: "numpad5",
-  Numpad6: "numpad6",
-  Numpad7: "numpad7",
-  Numpad8: "numpad8",
-  Numpad9: "numpad9",
+const KEY_CODE_MAIN_KEY_MAP: Record<string, string> = {
+  Backspace: "backspace",
+  Delete: "delete",
+  Insert: "insert",
+  Home: "home",
+  End: "end",
+  PageUp: "pageup",
+  PageDown: "pagedown",
+  ArrowUp: "up",
+  ArrowDown: "down",
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  Enter: "enter",
+  Tab: "tab",
+  Space: "space",
+  Escape: "escape",
+  CapsLock: "capslock",
+  NumLock: "numlock",
+  ScrollLock: "scrolllock",
+  PrintScreen: "printscreen",
+  Pause: "pause",
+  ContextMenu: "menu",
   NumpadAdd: "numpadadd",
   NumpadSubtract: "numpadsubtract",
   NumpadMultiply: "numpadmultiply",
   NumpadDivide: "numpaddivide",
   NumpadDecimal: "numpaddecimal",
-  NumpadEnter: "numpadenter",
 };
 
 const NUMPAD_LOCATION_KEY_MAP: Record<string, string> = {
@@ -69,17 +92,109 @@ const NUMPAD_LOCATION_KEY_MAP: Record<string, string> = {
   "*": "numpadmultiply",
   "/": "numpaddivide",
   ".": "numpaddecimal",
-  enter: "numpadenter",
 };
 
 type LayoutMapLike = {
   get(code: string): string | undefined;
 };
 
+type KeyboardCaptureEvent = {
+  key: string;
+  code?: string;
+  location?: number;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  metaKey: boolean;
+};
+
+type MouseCaptureEvent = {
+  button: number;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  metaKey: boolean;
+};
+
 let layoutMapPromise: Promise<LayoutMapLike | null> | null = null;
 
 function normalizeModifierToken(token: string): string | null {
   return MODIFIER_ALIASES[token.trim().toLowerCase()] ?? null;
+}
+
+function normalizeMouseToken(token: string): string | null {
+  const lower = token.trim().toLowerCase();
+
+  const mouseMap: Record<string, string> = {
+    mouseleft: "mouseleft",
+    leftmouse: "mouseleft",
+    leftbutton: "mouseleft",
+    mouse1: "mouseleft",
+    lmb: "mouseleft",
+    mouseright: "mouseright",
+    rightmouse: "mouseright",
+    rightbutton: "mouseright",
+    mouse2: "mouseright",
+    rmb: "mouseright",
+    mousemiddle: "mousemiddle",
+    middlemouse: "mousemiddle",
+    middlebutton: "mousemiddle",
+    mouse3: "mousemiddle",
+    mmb: "mousemiddle",
+    scrollbutton: "mousemiddle",
+    middleclick: "mousemiddle",
+    mouse4: "mouse4",
+    xbutton1: "mouse4",
+    mouseback: "mouse4",
+    browserback: "mouse4",
+    backbutton: "mouse4",
+    mouse5: "mouse5",
+    xbutton2: "mouse5",
+    mouseforward: "mouse5",
+    browserforward: "mouse5",
+    forwardbutton: "mouse5",
+  };
+
+  return mouseMap[lower] ?? null;
+}
+
+function normalizeNumpadToken(token: string): string | null {
+  const lower = token.trim().toLowerCase();
+
+  if (/^numpad[0-9]$/.test(lower)) {
+    return lower;
+  }
+
+  if (/^num[0-9]$/.test(lower)) {
+    return `numpad${lower.slice(3)}`;
+  }
+
+  const numpadMap: Record<string, string> = {
+    numpadadd: "numpadadd",
+    numadd: "numpadadd",
+    numplus: "numpadadd",
+    numpadplus: "numpadadd",
+    numpadsubtract: "numpadsubtract",
+    numsubtract: "numpadsubtract",
+    numsub: "numpadsubtract",
+    numminus: "numpadsubtract",
+    numpadminus: "numpadsubtract",
+    numpadmultiply: "numpadmultiply",
+    nummultiply: "numpadmultiply",
+    nummul: "numpadmultiply",
+    numpadmul: "numpadmultiply",
+    numpaddivide: "numpaddivide",
+    numdivide: "numpaddivide",
+    numdiv: "numpaddivide",
+    numpaddiv: "numpaddivide",
+    numpaddecimal: "numpaddecimal",
+    numdecimal: "numpaddecimal",
+    numdot: "numpaddecimal",
+    numdel: "numpaddecimal",
+    numpadpoint: "numpaddecimal",
+  };
+
+  return numpadMap[lower] ?? null;
 }
 
 function normalizeNamedKey(key: string): string | null {
@@ -100,40 +215,17 @@ function normalizeNamedKey(key: string): string | null {
     arrowdown: "down",
     arrowleft: "left",
     arrowright: "right",
-    mouseleft: "mouseleft",
-    mouse1: "mouseleft",
-    mouseright: "mouseright",
-    mouse2: "mouseright",
-    mousemiddle: "mousemiddle",
-    mouse3: "mousemiddle",
-    scrollbutton: "mousemiddle",
-    middleclick: "mousemiddle",
-    mouse4: "mouse4",
-    mouseback: "mouse4",
-    xbutton1: "mouse4",
-    mouse5: "mouse5",
-    mouseforward: "mouse5",
-    xbutton2: "mouse5",
-    scrollup: "scrollup",
-    wheelup: "scrollup",
-    scrolldown: "scrolldown",
-    wheeldown: "scrolldown",
-    numpad0: "numpad0",
-    numpad1: "numpad1",
-    numpad2: "numpad2",
-    numpad3: "numpad3",
-    numpad4: "numpad4",
-    numpad5: "numpad5",
-    numpad6: "numpad6",
-    numpad7: "numpad7",
-    numpad8: "numpad8",
-    numpad9: "numpad9",
-    numpadadd: "numpadadd",
-    numpadsubtract: "numpadsubtract",
-    numpadmultiply: "numpadmultiply",
-    numpaddivide: "numpaddivide",
-    numpaddecimal: "numpaddecimal",
-    numpadenter: "numpadenter",
+    capslock: "capslock",
+    numlock: "numlock",
+    scrolllock: "scrolllock",
+    printscreen: "printscreen",
+    pause: "pause",
+    break: "pause",
+    contextmenu: "menu",
+    apps: "menu",
+    menu: "menu",
+    escape: "escape",
+    esc: "escape",
   };
 
   if (/^f\d{1,2}$/i.test(key)) {
@@ -143,20 +235,63 @@ function normalizeNamedKey(key: string): string | null {
   return keyMap[lower] ?? null;
 }
 
-function normalizeNumpadFromCode(
-  code: string | undefined,
+function mainKeyFromCode(
+  code: string,
   key: string,
-  location: number | undefined,
+  location?: number,
 ): string | null {
-  if (code && NUMPAD_CODE_MAP[code]) {
-    return NUMPAD_CODE_MAP[code];
+  if (code === "IntlBackslash") {
+    return "IntlBackslash";
   }
 
-  if (location !== 3) {
-    return null;
+  if (/^Key[A-Z]$/.test(code)) {
+    return code;
   }
 
-  return NUMPAD_LOCATION_KEY_MAP[key.toLowerCase()] ?? null;
+  if (/^Digit[0-9]$/.test(code)) {
+    return code;
+  }
+
+  if (/^Numpad[0-9]$/.test(code)) {
+    return `numpad${code.slice(6)}`;
+  }
+
+  if (location === 3) {
+    const locationMapped = NUMPAD_LOCATION_KEY_MAP[key.toLowerCase()];
+    if (locationMapped) {
+      return locationMapped;
+    }
+  }
+
+  return KEY_CODE_MAIN_KEY_MAP[code] ?? null;
+}
+
+function mainKeyFromKey(key: string): string | null {
+  if (key === " ") return "space";
+
+  const normalizedNamedKey = normalizeNamedKey(key);
+  return (
+    normalizedNamedKey ??
+    normalizeNumpadToken(key) ??
+    normalizeMouseToken(key) ??
+    (SHIFTED_SYMBOL_BASE_MAP[key] ?? (key.length === 1 ? key.toLowerCase() : null))
+  );
+}
+
+function buildHotkeyString(
+  mainKey: string,
+  event: Pick<
+    KeyboardCaptureEvent,
+    "ctrlKey" | "altKey" | "shiftKey" | "metaKey"
+  >,
+): string {
+  const parts: string[] = [];
+  if (event.ctrlKey) parts.push("ctrl");
+  if (event.altKey) parts.push("alt");
+  if (event.shiftKey) parts.push("shift");
+  if (event.metaKey) parts.push("super");
+  parts.push(mainKey);
+  return parts.join("+");
 }
 
 function displayTokenFromStoredValue(
@@ -180,11 +315,16 @@ function displayTokenFromStoredValue(
     return trimmed.slice(5);
   }
 
-  if (NUMPAD_CODE_MAP[trimmed]) {
-    return displayTokenFromStoredValue(NUMPAD_CODE_MAP[trimmed], layoutMap);
+  if (/^Numpad[0-9]$/.test(trimmed)) {
+    return `Num ${trimmed.slice(6)}`;
   }
 
   const lower = trimmed.toLowerCase();
+
+  if (/^numpad[0-9]$/.test(lower)) {
+    return `Num ${lower.slice(6)}`;
+  }
+
   const namedDisplayMap: Record<string, string> = {
     up: "Up",
     down: "Down",
@@ -202,29 +342,22 @@ function displayTokenFromStoredValue(
     space: "Space",
     escape: "Esc",
     esc: "Esc",
-    mouseleft: "Mouse Left",
-    mouseright: "Mouse Right",
-    mousemiddle: "Scroll Button",
-    mouse4: "Mouse Back",
-    mouse5: "Mouse Forward",
-    scrollup: "Scroll Up",
-    scrolldown: "Scroll Down",
-    numpad0: "Num 0",
-    numpad1: "Num 1",
-    numpad2: "Num 2",
-    numpad3: "Num 3",
-    numpad4: "Num 4",
-    numpad5: "Num 5",
-    numpad6: "Num 6",
-    numpad7: "Num 7",
-    numpad8: "Num 8",
-    numpad9: "Num 9",
+    capslock: "Caps Lock",
+    numlock: "Num Lock",
+    scrolllock: "Scroll Lock",
+    printscreen: "Print Screen",
+    pause: "Pause",
+    menu: "Menu",
     numpadadd: "Num +",
     numpadsubtract: "Num -",
     numpadmultiply: "Num *",
     numpaddivide: "Num /",
     numpaddecimal: "Num .",
-    numpadenter: "Num Enter",
+    mouseleft: "Mouse Left",
+    mouseright: "Mouse Right",
+    mousemiddle: "Mouse Middle",
+    mouse4: "Mouse Back",
+    mouse5: "Mouse Forward",
   };
 
   if (namedDisplayMap[lower]) {
@@ -254,16 +387,12 @@ function normalizeStoredMainKey(
     return trimmed.slice(5);
   }
 
-  if (NUMPAD_CODE_MAP[trimmed]) {
-    return NUMPAD_CODE_MAP[trimmed];
+  if (/^Numpad[0-9]$/.test(trimmed)) {
+    return `numpad${trimmed.slice(6)}`;
   }
 
   const lower = trimmed.toLowerCase();
-  if (normalizeNamedKey(lower)?.startsWith("numpad")) {
-    return normalizeNamedKey(lower)!;
-  }
-
-  if (lower === "<" || lower === ">") {
+  if (lower === "<" || lower === ">" || lower === "intlbackslash") {
     return "IntlBackslash";
   }
 
@@ -271,7 +400,12 @@ function normalizeStoredMainKey(
     return SHIFTED_SYMBOL_BASE_MAP[trimmed];
   }
 
-  return normalizeNamedKey(trimmed) ?? lower;
+  return (
+    normalizeMouseToken(trimmed) ??
+    normalizeNumpadToken(trimmed) ??
+    normalizeNamedKey(trimmed) ??
+    lower
+  );
 }
 
 export async function getKeyboardLayoutMap(): Promise<LayoutMapLike | null> {
@@ -293,97 +427,34 @@ export async function canonicalizeHotkeyForBackend(value: string): Promise<strin
   return canonicalizeHotkeyString(value, layoutMap);
 }
 
-export function captureHotkey(event: {
-  key: string;
-  code?: string;
-  location?: number;
-  ctrlKey: boolean;
-  altKey: boolean;
-  shiftKey: boolean;
-  metaKey: boolean;
-}): string | null {
-  const lower = event.key.toLowerCase();
-  if (MODIFIER_KEYS.has(lower) || lower === "escape") {
-    return null;
-  }
+export function captureHotkey(event: KeyboardCaptureEvent): string | null {
+  const lowerKey = event.key.toLowerCase();
+
+  if (MODIFIER_KEYS.has(lowerKey)) return null;
+  if (event.code && MODIFIER_CODES.has(event.code)) return null;
+  if (lowerKey === "escape" || event.code === "Escape") return null;
 
   const mainKey =
-    normalizeNumpadFromCode(event.code, event.key, event.location) ??
-    (event.key === " " ? "space" : null) ??
-    normalizeNamedKey(event.key) ??
-    (SHIFTED_SYMBOL_BASE_MAP[event.key] ?? (event.key.length === 1 ? lower : null));
+    (event.code ? mainKeyFromCode(event.code, event.key, event.location) : null) ??
+    mainKeyFromKey(event.key);
 
-  if (!mainKey) {
-    return null;
-  }
-
-  const parts: string[] = [];
-  if (event.ctrlKey) parts.push("ctrl");
-  if (event.altKey) parts.push("alt");
-  if (event.shiftKey) parts.push("shift");
-  if (event.metaKey) parts.push("super");
-  parts.push(mainKey);
-  return parts.join("+");
-}
-
-export function captureMouseHotkey(
-  event: {
-    button: number;
-    ctrlKey: boolean;
-    altKey: boolean;
-    shiftKey: boolean;
-    metaKey: boolean;
-  },
-  clickerMouseButton?: string,
-): string | null {
-  const mouseMap: Record<number, string> = {
-    0: "mouseleft",
-    1: "mousemiddle",
-    2: "mouseright",
-    3: "mouse4",
-    4: "mouse5",
-  };
-
-  const mainKey = mouseMap[event.button];
   if (!mainKey) return null;
 
-  if (clickerMouseButton === "Left" && mainKey === "mouseleft") return null;
-  if (clickerMouseButton === "Middle" && mainKey === "mousemiddle") return null;
-  if (clickerMouseButton === "Right" && mainKey === "mouseright") return null;
-
-  if (event.button === 0) {
-    const hasModifier =
-      event.ctrlKey || event.altKey || event.shiftKey || event.metaKey;
-    if (!hasModifier) return null;
-  }
-
-  const parts: string[] = [];
-  if (event.ctrlKey) parts.push("ctrl");
-  if (event.altKey) parts.push("alt");
-  if (event.shiftKey) parts.push("shift");
-  if (event.metaKey) parts.push("super");
-  parts.push(mainKey);
-  return parts.join("+");
+  return buildHotkeyString(mainKey, event);
 }
 
-export function captureWheelHotkey(event: {
-  deltaY: number;
-  ctrlKey: boolean;
-  altKey: boolean;
-  shiftKey: boolean;
-  metaKey: boolean;
-}): string | null {
-  if (event.deltaY === 0) return null;
+export function captureMouseHotkey(event: MouseCaptureEvent): string | null {
+  const mainKey =
+    {
+      0: "mouseleft",
+      1: "mousemiddle",
+      2: "mouseright",
+      3: "mouse4",
+      4: "mouse5",
+    }[event.button] ?? null;
 
-  const mainKey = event.deltaY < 0 ? "scrollup" : "scrolldown";
-
-  const parts: string[] = [];
-  if (event.ctrlKey) parts.push("ctrl");
-  if (event.altKey) parts.push("alt");
-  if (event.shiftKey) parts.push("shift");
-  if (event.metaKey) parts.push("super");
-  parts.push(mainKey);
-  return parts.join("+");
+  if (!mainKey) return null;
+  return buildHotkeyString(mainKey, event);
 }
 
 export function formatHotkeyForDisplay(
@@ -413,7 +484,10 @@ function canonicalizeHotkeyString(
   value: string,
   layoutMap: LayoutMapLike | null,
 ): string {
-  const parts: string[] = [];
+  let ctrl = false;
+  let alt = false;
+  let shift = false;
+  let superKey = false;
   let mainKey: string | null = null;
 
   for (const rawPart of value.split("+")) {
@@ -422,18 +496,21 @@ function canonicalizeHotkeyString(
 
     const modifier = normalizeModifierToken(part);
     if (modifier) {
-      if (!parts.includes(modifier)) {
-        parts.push(modifier);
-      }
+      if (modifier === "ctrl") ctrl = true;
+      if (modifier === "alt") alt = true;
+      if (modifier === "shift") shift = true;
+      if (modifier === "super") superKey = true;
       continue;
     }
 
     mainKey = normalizeStoredMainKey(part, layoutMap);
   }
 
-  if (mainKey) {
-    parts.push(mainKey);
-  }
-
+  const parts: string[] = [];
+  if (ctrl) parts.push("ctrl");
+  if (alt) parts.push("alt");
+  if (shift) parts.push("shift");
+  if (superKey) parts.push("super");
+  if (mainKey) parts.push(mainKey);
   return parts.join("+");
 }


### PR DESCRIPTION
## Summary

This PR makes hotkey binding reliable for mouse buttons, side buttons, and numpad keys.

The previous implementation was too fragile because hotkey capture, display, storage, and backend parsing all used different rules. It relied mostly on `event.key` in the focused input and a narrow backend parser, which meant mouse buttons could not be captured properly, side buttons were unsupported, and numpad keys were often collapsed into regular keyboard symbols instead of being treated as distinct inputs.

## What changed

- added direct hotkey capture for mouse buttons, including side buttons
- normalized hotkeys consistently across capture, display, storage, and backend parsing
- distinguished numpad keys and operators from their non-numpad equivalents
- expanded backend virtual-key parsing for mouse buttons, numpad keys, function keys, and additional named keys
- prevented mouse input from leaking through while the hotkey field is actively listening

Fixes #7, #8, #19, #23, #32, #34, #38, #42, #51, #56, and #60.
