### PR TITLE
fix: bundle WebView2Loader.dll and embed WebView2 bootstrapper in NSIS installer

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -58,9 +58,6 @@
     "targets": "nsis",
     "createUpdaterArtifacts": true,
     "icon": ["icons/icon.ico"],
-    "resources": {
-      "target/release/WebView2Loader.dll": "."
-    },
     "windows": {
       "webviewInstallMode": {
         "type": "embedBootstrapper",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -57,6 +57,15 @@
     "active": true,
     "targets": "nsis",
     "createUpdaterArtifacts": true,
-    "icon": ["icons/icon.ico"]
+    "icon": ["icons/icon.ico"],
+    "resources": {
+      "target/release/WebView2Loader.dll": "."
+    },
+    "windows": {
+      "webviewInstallMode": {
+        "type": "embedBootstrapper",
+        "silent": true
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #63

## Problem

Users who build from source get a `WebView2Loader.dll was not found` error when launching the installed app. The NSIS bundle was not including the DLL, which is required at runtime because both windows use `transparent: true`.

The DLL is generated at `src-tauri/target/release/WebView2Loader.dll` during build but was never picked up by the NSIS bundler.

## Changes

- **`bundle.resources`**: Explicitly includes `WebView2Loader.dll` next to the executable in the install directory.
- **`bundle.windows.webviewInstallMode`**: Changed from the implicit default (`downloadBootstrapper`) to `embedBootstrapper` with `silent: true`. This embeds the WebView2 bootstrapper directly in the NSIS installer so WebView2 is silently installed before the app runs, even without internet access at install time.