### PR TITLE
ci: add GitHub Actions workflow for frontend and Rust validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  frontend:
+    name: Frontend (lint + type check + build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check and build
+        run: npm run build
+
+  rust:
+    name: Rust (check + test)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workdir: src-tauri
+
+      - name: Check
+        working-directory: src-tauri
+        run: cargo check
+
+      - name: Test
+        working-directory: src-tauri
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   frontend:


### PR DESCRIPTION
Closes #35

## What

Adds `.github/workflows/ci.yml` with two parallel jobs that run on every push and PR to `main`:

- **frontend** (`ubuntu-latest`): `npm ci` → lint → `tsc + vite build`
- **rust** (`windows-latest`): `cargo check` → `cargo test`

## Why two jobs?

The Rust code uses Windows-only APIs (`windows-sys`, hotkeys, mouse input) so it must compile on `windows-latest`. The frontend has no such constraint so it runs on `ubuntu-latest` which is faster and cheaper. Running them in parallel keeps total CI time low.

## Caching

- Node: `actions/setup-node` cache on `npm`
- Rust: `Swatinem/rust-cache` pointed at `src-tauri/` to avoid recompiling dependencies on every run