### PR TITLE
feat: add presets, persistent pinning, and accent color customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+## New
+- Added named presets for saving and reusing clicker configurations.
+- Added persistent Always on Top preference.
+- Added accent color customization for active UI states.
+
+## Changed
+- Centralized frontend settings bounds, options, and preset helpers.
+- Cleaned up runtime stats logging output and changelog encoding issues.
+
 # v3.4.1 - 16.06.2026 (d.m.y)
 ## ❇️ New:
 - added a settings toggle for relaxed / strict keybind mode.
@@ -10,170 +20,162 @@
 ## 🔺 Fix:
 - Windows Text Scaling should now work properly (thank you Rorky47 & David-T-Campos for the help)
 
-
-
 # v3.4.0 - 15.05.2026 (d.m.y)
-## ❇️ New:
+## New
 - Added Light Mode with Light / Dark toggle in the settings
 - Added support for Mouse Buttons and Numpads
-## 🔹 Changed:
+
+## Changed
 - Hotkey recognition should now be more reliable.
 - Adjusted fonts and colors for light mode
 - Edge / Corner stop now supports multiple monitors
 - Added vertical bars to Simple mode Hold and Randomization fields for consistency.
-## 🔺 Fix:
+
+## Fix
 - Fixed Time Limit hover card being split in 2
 
 # v3.3.0 - 14.04.2026 (d.m.y)
-## ❇️ New:
-- added Github link icon
-- added Scroll bar for settings page
-## 🔹 Changed:
+## New
+- Added GitHub link icon
+- Added scroll bar for settings page
+
+## Changed
 - Simple Mode UI
 - Icons for top bar instead of text buttons
 - Resize animation for horizontal resizing
-- Randomization and Duty cycle are now in simple mode. 
-## 🔺 Fix:
+- Randomization and Duty cycle are now in simple mode.
+
+## Fix
 - Fixed double click on top bar maximizing the window.
 - Speed Variation not graying out when off
 - Speed Variation should act more like intended
-## 🪦 Removed:
-- Removed Telemetry. Your local data will also be reset but it is what it is
+
+## Removed
+- Removed Telemetry. Your local data will also be reset but it is what it is.
 - Duty Cycle On/Off button
-- Local verification for stats (if you want to make your own fake stats, go ahead ig)
+- Local verification for stats
 
 # v3.2.0 - 11.04.2026 (d.m.y)
-## ❇️ New Features:
-- Added an Overlay for the edge / corner stop features. This was a major pain and i am not done with it yet. the current implementation is more of a test.
-## 🔹 Changed:
+## New Features
+- Added an overlay for the edge / corner stop features.
+
+## Changed
 - Replaced GetProcessTimes with QueryThreadCycleTime for CPU usage measurement. This gives a more accurate representation of the CPU time used by the clicker. All runs should now output accurate CPU usage, even if the clicker only ran for a single millisecond. The trade-off is that CPU usage is now measured for only the clicker thread instead of the entire app, though the clicker thread is the main source of CPU usage anyway.
 - Polling for update every hour instead of on app launch.
-## 🔺 Fix:
-- Added timeout for writing settings, this prevents settings race condition. (Usually a non-issue, but it's best practice)
-## 🔸 Performance Updates:
-- Changed sending telemetry from its own tokio runtime to using the tauri async runtime.
-## 🪦 Removed:
-- Removed unused stop_clicker() function (stopping is handled via the running atomic flag)
 
+## Fix
+- Added timeout for writing settings to prevent a settings race condition.
+
+## Performance Updates
+- Changed sending telemetry from its own tokio runtime to using the Tauri async runtime.
+
+## Removed
+- Removed unused `stop_clicker()` function.
 
 # v3.1.0 - 07.04.2026 (d.m.y)
-## ❇️ New Features:
-- Added AUTO UPDATES (this is a big one, I know :3)
+## New Features
+- Added auto updates
 - Added social links in the settings page
-- Added clicker stop reasoning in advanced mode (title turns into whatever reason stopped the clicker)
-## 🔹 Changed:
-- Replaced printl with logging module (not really relevant for uesers)
-  
+- Added clicker stop reasoning in advanced mode
+
+## Changed
+- Replaced `println!` with the logging module
+
 # v3.0.0 - 04.04.2026 (d.m.y)
-## ❇️ New Features:
+## New Features
 1. Mode pages (Simple, Advanced, Macro) to make the UI less cluttered and more user friendly.
 2. Added dedicated Settings page to make it easier to find and change settings.
 3. Added explanations for each setting in the Advanced mode to make it easier for new users to understand what each setting does.
-4. Encryption key for stats so it can not be modified by the user (this stops people from cheating the stats by modifying the local data.)
+4. Encryption key for stats so it cannot be modified by the user.
 5. Added Edge Stop to disable the clicker near screen edges.
-6. Added Corner Stop to disable the clicker near screen corners. that could've been combined with the Edge stop point but this way there is a higher number in the changelog which means im better at coding.
+6. Added Corner Stop to disable the clicker near screen corners.
 7. Added a "Clear" button to the stats page to clear local data.
-8. Telemetry now only sends data collected while enabled (turns out sending old data isn’t exactly legal :/)
+8. Telemetry now only sends data collected while enabled.
 9. On / Off buttons for most advanced settings have been added.
-10. Added double click feature. Limited to a max of 50cps to prevent.. stuff not working
-## 🔹 Changed:
-1. local data storage has been revamped to consolidate results every 100 lines so file size doesn't get out of hand (very minor issue, would have only taken up a few mb every month, but I wanted to do it anyway :3)
-2. Preparations for Auto Updater (not implemented yet, but the backend is there for when I do implement it)
-3. Entire UI has been redone and moved from python pyside6 to rust and the Tauri framework. This should make the UI easier to look at, and expand for future features.
+10. Added double click feature. Limited to a max of 50 CPS.
+
+## Changed
+1. Local data storage has been revamped to consolidate results every 100 lines so file size does not get out of hand.
+2. Preparations for Auto Updater.
+3. Entire UI has been redone and moved from Python / PySide6 to Rust and Tauri.
 4. Stored data does not get sent to the backend anymore if telemetry is not enabled, but it is still stored locally and can be viewed in the stats page.
-5. I won't list every single UI change, but everything is different (and hopefully better)
+5. Everything in the UI has changed.
 6. Version number has been moved to the settings page only.
-7. No more dropdowns which should make it a bit easier to see all the options at a glance.
-8. Multi monitor support added! you can now click on your secondary monitor :)
-9. Made a total of 5 files from the previous version into almost 40 files, but the code is hopefully easier to navigate for me now.
-## 🔺 Fix:
-1. Probably fixed a few things along the way (6000+ lines of NEW code will do that :3)
-## 🔸 Performance Updates:
-1. moving to rust entirely eliminated the Python runtime, which should slightly increase performance.
-## 🪦 Removed:
-1. Mouse move options for now until I work on the Macro panel.
-2. your old stats (sorry :3) because of the new encryption method, but you can still see them in the old stats file if you want to cry over your lost 100billion clicks.
+7. No more dropdowns which should make it easier to see all the options at a glance.
+8. Multi-monitor support added.
+9. The codebase was split into many more files to make it easier to navigate.
+
+## Fix
+1. Probably fixed a few things along the way.
+
+## Performance Updates
+1. Moving to Rust entirely eliminated the Python runtime, which should slightly increase performance.
+
+## Removed
+1. Mouse move options for now until the Macro panel is ready.
+2. Old stats because of the new encryption method.
 
 ---
 
 # v2.1.2 - 22.03.2026 (d.m.y)
-## 🔺 Fix:
-- Drop down selector for Second / Minute / Hour / Day used to always return per second, meaning sub 1cps could not be achieved.
-selector has been fixed by removing ".lower()" from the code :3 (thats coding for ya)
-- Minimum Duty cycle has been reduced from 1% to 0.1% to help with the mouse being held down for too long during sub 1s click times.
+## Fix
+- Drop-down selector for Second / Minute / Hour / Day used to always return per second, meaning sub-1 CPS could not be achieved.
+- Minimum Duty cycle has been reduced from 1% to 0.1% to help with the mouse being held down for too long during sub-1s click times.
 
 # v2.1.1 - 24.02.2026 (d.m.y)
-## 🔺 Fix:
-- CPU logging does not report 0.0% value if no samples are made (previously lowered average cpu usage artificially)
+## Fix
+- CPU logging does not report 0.0% if no samples are made.
 - CPU logging frequency is dynamic, making the averages more accurate at lower runtimes.
 
 # v2.1.0 - 23.02.2026 (d.m.y)
-## ❇️ New Features:
-- Added Opt-in Telemetry Popup (Honestly didn't wanna do that but EU laws and stuff :3)
-- measure and log cpu usage
-- Changed Data collection from Google to Supabase
-- Moved ENTIE backend to Rust for better peformance
-- logging of clicker session time and total time, session clicks and total clicks
-- click status has a greer outline while active, making it more obvious that the auto clicker has been turned on.
+## New Features
+- Added opt-in telemetry popup
+- Measure and log CPU usage
+- Changed data collection from Google to Supabase
+- Moved the entire backend to Rust for better performance
+- Added logging of clicker session time and total time, session clicks, and total clicks
+- Click status has a greener outline while active
 
-## 🔹 Changed:
-- Keybind field automatically unfocuses so that it doesn't bug out when you instantly try to activate the autoclicker without removing focus from the field.
-- Refractor of:
-     - main.py
-     - settings_manager.py
-     - hotkey_manager.py
-     - rust_translation.py
-- updated file structure
-- Config.ini now saves at %appdata%/blur009/autoclicker/config.ini
-- split up main.py into individual files to reduce line count per file.
-- ReadMe Updated
+## Changed
+- Keybind field automatically unfocuses so that it does not bug out when you instantly try to activate the autoclicker without removing focus from the field.
+- Refactor of:
+  - `main.py`
+  - `settings_manager.py`
+  - `hotkey_manager.py`
+  - `rust_translation.py`
+- Updated file structure
+- `Config.ini` now saves at `%appdata%/blur009/autoclicker/config.ini`
+- Split up `main.py` into individual files to reduce line count per file.
+- README updated
 
-## 🔺 Fix:
+## Performance Updates
+- Switching to Rust massively increased performance, dropping CPU usage by several percent.
 
-## 🔸 Performance Updates:
-- switching to rust massively increased performance, dropping cpu usage by ceveral percent. (down to ~1%avg during use on my system)
-
-## 🪦 Removed:
-- Switch to Go was good, but I realized after way too much debugging that syscall took 84% of my runtime performance. So, to Rust we go.. (Go was basically talking to itsself over and over to do the clicks, while Rust is doing it directly, which is why the performance increase is so big).
-
+## Removed
+- Switched away from Go after debugging showed syscall overhead was too expensive.
 
 # v2.0.0 - 18.02.2026 (d.m.y)
-
-## ❇️ New Features:
+## New Features
 - Added On / Off hint next to the shortcut field.
 - Added smoothing to the mouse movement to combat the "teleporting" of the cursor.
 - Added an Offset Chance button that makes the Click Offset only happen sometimes.
-- Added Anonymous Telemetry to find the most common settings people use/don't use
-- Added Info about Telemetry and support options in Program Settings
-- Added an Advanced Options button that makes the gui simpler for ppl who need a simple auto clicker :3
+- Added anonymous telemetry to find the most common settings people use or do not use.
+- Added info about telemetry and support options in Program Settings.
+- Added an Advanced Options button that makes the GUI simpler for people who need a simple auto clicker.
 
-## 🔹 Changed:
-- Changed the UI to be less complex and more user-friendly (I hope).
-- Changed UI to adjust to the window size when enabling/disabling Advanced options (took 4ever)
-- Increased Click Speed cap to different values depending on the selected time frame (second, minute, hour, day). It is not recommended to use speeds over 500 even though it is technically possible.
-- Renamed Scripts folder to src
-- Split some UI and Settings features into settings_manager.py to clean up main.py
-- very sneaky shark emoji hidden somewhere in the code. You get a cookie if you find it.
+## Changed
+- Changed the UI to be less complex and more user-friendly.
+- Changed UI to adjust to the window size when enabling and disabling Advanced options.
+- Increased Click Speed cap to different values depending on the selected time frame.
+- Renamed Scripts folder to `src`
+- Split some UI and Settings features into `settings_manager.py` to clean up `main.py`
 
-## 🔺 Fix:
-- Fixed the Offset to apply in the radius of a circle instead of a square around the set position  
-(not really a "bug" but this is the way I wanted it to work when I thought of the feature).
+## Fix
+- Fixed the Offset to apply in the radius of a circle instead of a square around the set position.
 
-## 🔸 Performance Updates:
-- Introduced click batching at higher cps to send multiple clicks every call. This allows for more clicks than before because windows pointer resolution was limiting the amount of calls that the clicker was able to make.
-- Variables are initialized outside the isRunning loop
-- more that I probably forgot because I've been sitting here for 10h making this work :3
-
-
-## ❇️ New Features:
+## Performance Updates
+- Introduced click batching at higher CPS to send multiple clicks every call.
+- Variables are initialized outside the `isRunning` loop.
 
 # v0.0.0 - ..202 (d.m.y)
-(just an empty template for me here)
-## 🔹 Changed:
-
-## 🔺 Fix:
-
-## 🔸 Performance Updates:
-
-## 🪦 Removed:
-
+Empty template entry.

--- a/src-tauri/src/engine/stats.rs
+++ b/src-tauri/src/engine/stats.rs
@@ -237,15 +237,12 @@ pub fn reset_stats() -> Result<CumulativeStats, String> {
 }
 
 pub fn print_run_stats(click_count: i64, elapsed_secs: f64, avg_cpu: f64) {
-    log::info!("╔══════════════════════════════════════╗");
-    log::info!("║          RUN STATISTICS              ║");
-    log::info!("╠══════════════════════════════════════╣");
-    log::info!("║  Clicks:  {:>20}       ║", click_count);
-    log::info!("║  Duration:   {:>17.1}s      ║", elapsed_secs);
+    log::info!("=== Run Statistics ===");
+    log::info!("Clicks: {}", click_count);
+    log::info!("Duration: {:.1}s", elapsed_secs);
     if avg_cpu >= 0.0 {
-        log::info!("║  Avg CPU:    {:>17.1}%      ║", avg_cpu);
+        log::info!("Avg CPU: {:.1}%", avg_cpu);
     } else {
-        log::info!("║  Avg CPU:    {:>20}      ║", "N/A");
+        log::info!("Avg CPU: N/A");
     }
-    log::info!("╚══════════════════════════════════════╝");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,7 +103,7 @@ pub fn run() {
                     Ok(Some(result)) => {
                         if result.update_available {
                             log::info!(
-                                "[Updates] Update available: {} → {}",
+                                "[Updates] Update available: {} -> {}",
                                 result.current_version,
                                 result.latest_version
                             );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,14 @@ import {
   LogicalSize,
 } from "@tauri-apps/api/window";
 import { lazy, useEffect, useRef, useState } from "react";
+import { applyAccentTheme } from "./accentTheme";
 import UpdateBanner from "./components/Updatebanner";
 import { canonicalizeHotkeyForBackend } from "./hotkeys";
+import {
+  buildPresetSnapshot,
+  createPresetDefinition,
+  type PresetId,
+} from "./settingsSchema";
 import {
   APP_VERSION,
   DEFAULT_SETTINGS,
@@ -29,11 +35,12 @@ const AdvancedPanelCompact = lazy(
 
 export type Tab = "simple" | "advanced" | "settings";
 
-const BACKEND_SETTINGS_SCHEMA_VERSION = 5;
+const BACKEND_SETTINGS_SCHEMA_VERSION = 7;
+const OPERATIONAL_SETTING_KEYS = new Set<string>(Object.keys(buildPresetSnapshot(DEFAULT_SETTINGS)));
 
 function getPanelSize(tab: Tab, settings: Settings, hasUpdate: boolean) {
   const extra = hasUpdate ? 30 : 0;
-  if (tab === "settings") return { width: 500, height: 600 + extra };
+  if (tab === "settings") return { width: 560, height: 720 + extra };
   if (tab === "simple") return { width: 550, height: 175 + extra };
   return settings.explanationMode === "off"
     ? { width: 600, height: 600 + extra }
@@ -79,6 +86,10 @@ const DEFAULT_APP_INFO: AppInfo = {
   version: APP_VERSION,
   updateStatus: "Update checks are disabled in development",
   screenshotProtectionSupported: false,
+};
+
+type UpdateSettingsOptions = {
+  preserveActivePreset?: boolean;
 };
 
 async function syncSettingsToBackend(settings: Settings) {
@@ -206,12 +217,31 @@ export default function App() {
     }, 250);
   };
 
-  const updateSettings = (patch: Partial<Settings>) => {
+  const updateSettings = (
+    patch: Partial<Settings>,
+    options: UpdateSettingsOptions = {},
+  ) => {
     const { hotkey, ...rest } = patch;
+    const shouldClearActivePreset =
+      !options.preserveActivePreset &&
+      (hotkey !== undefined ||
+        Object.keys(rest).some((key) => OPERATIONAL_SETTING_KEYS.has(key)));
 
-    if (Object.keys(rest).length > 0) {
-      const nextUiSettings = { ...uiSettingsRef.current, ...rest };
-      const nextCommittedSettings = { ...committedSettingsRef.current, ...rest };
+    const restPatch: Partial<Settings> = { ...rest };
+    if (
+      shouldClearActivePreset &&
+      patch.activePresetId === undefined &&
+      committedSettingsRef.current.activePresetId !== null
+    ) {
+      restPatch.activePresetId = null;
+    }
+
+    if (Object.keys(restPatch).length > 0) {
+      const nextUiSettings = { ...uiSettingsRef.current, ...restPatch };
+      const nextCommittedSettings = {
+        ...committedSettingsRef.current,
+        ...restPatch,
+      };
       persistCommittedSettings(nextCommittedSettings, nextUiSettings);
     }
 
@@ -236,6 +266,183 @@ export default function App() {
     }
   };
 
+  const handleToggleAlwaysOnTop = async () => {
+    const nextValue = !committedSettingsRef.current.alwaysOnTop;
+
+    try {
+      await getCurrentWindow().setAlwaysOnTop(nextValue);
+      updateSettings(
+        {
+          alwaysOnTop: nextValue,
+        },
+        { preserveActivePreset: true },
+      );
+    } catch (err) {
+      console.error("Failed to set always on top:", err);
+    }
+  };
+
+  const handleSavePreset = (name: string) => {
+    if (status.running) {
+      return false;
+    }
+
+    const preset = createPresetDefinition(name, committedSettingsRef.current);
+    if (!preset.name) {
+      return false;
+    }
+
+    const nextPresets = [...committedSettingsRef.current.presets, preset];
+    const nextCommittedSettings = {
+      ...committedSettingsRef.current,
+      presets: nextPresets,
+      activePresetId: preset.id,
+    };
+    const nextUiSettings = {
+      ...uiSettingsRef.current,
+      presets: nextPresets,
+      activePresetId: preset.id,
+    };
+
+    persistCommittedSettings(nextCommittedSettings, nextUiSettings);
+    return true;
+  };
+
+  const handleApplyPreset = (presetId: PresetId) => {
+    if (status.running) {
+      return false;
+    }
+
+    const preset = committedSettingsRef.current.presets.find(
+      (item) => item.id === presetId,
+    );
+    if (!preset) {
+      return false;
+    }
+
+    updateSettings(
+      {
+        ...preset.settings,
+        activePresetId: presetId,
+      },
+      { preserveActivePreset: true },
+    );
+    return true;
+  };
+
+  const handleUpdatePreset = (presetId: PresetId) => {
+    if (status.running) {
+      return false;
+    }
+
+    const nextSnapshot = buildPresetSnapshot(committedSettingsRef.current);
+
+    let updated = false;
+    const nextPresets = committedSettingsRef.current.presets.map((preset) => {
+      if (preset.id !== presetId) {
+        return preset;
+      }
+
+      updated = true;
+      return {
+        ...preset,
+        updatedAt: new Date().toISOString(),
+        settings: nextSnapshot,
+      };
+    });
+
+    if (!updated) {
+      return false;
+    }
+
+    const nextCommittedSettings = {
+      ...committedSettingsRef.current,
+      presets: nextPresets,
+      activePresetId: presetId,
+    };
+    const nextUiSettings = {
+      ...uiSettingsRef.current,
+      presets: nextPresets,
+      activePresetId: presetId,
+    };
+
+    persistCommittedSettings(nextCommittedSettings, nextUiSettings);
+    return true;
+  };
+
+  const handleRenamePreset = (presetId: PresetId, name: string) => {
+    if (status.running) {
+      return false;
+    }
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      return false;
+    }
+
+    let updated = false;
+    const nextPresets = committedSettingsRef.current.presets.map((preset) => {
+      if (preset.id !== presetId) {
+        return preset;
+      }
+
+      updated = true;
+      return {
+        ...preset,
+        name: trimmedName,
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    if (!updated) {
+      return false;
+    }
+
+    const nextCommittedSettings = {
+      ...committedSettingsRef.current,
+      presets: nextPresets,
+    };
+    const nextUiSettings = {
+      ...uiSettingsRef.current,
+      presets: nextPresets,
+    };
+
+    persistCommittedSettings(nextCommittedSettings, nextUiSettings);
+    return true;
+  };
+
+  const handleDeletePreset = (presetId: PresetId) => {
+    if (status.running) {
+      return false;
+    }
+
+    const nextPresets = committedSettingsRef.current.presets.filter(
+      (preset) => preset.id !== presetId,
+    );
+    if (nextPresets.length === committedSettingsRef.current.presets.length) {
+      return false;
+    }
+
+    const nextActivePresetId =
+      committedSettingsRef.current.activePresetId === presetId
+        ? null
+        : committedSettingsRef.current.activePresetId;
+
+    const nextCommittedSettings = {
+      ...committedSettingsRef.current,
+      presets: nextPresets,
+      activePresetId: nextActivePresetId,
+    };
+    const nextUiSettings = {
+      ...uiSettingsRef.current,
+      presets: nextPresets,
+      activePresetId: nextActivePresetId,
+    };
+
+    persistCommittedSettings(nextCommittedSettings, nextUiSettings);
+    return true;
+  };
+
   useEffect(() => {
     let mounted = true;
 
@@ -247,6 +454,8 @@ export default function App() {
       .then(async ([loadedSettings, loadedAppInfo, loadedStatus]) => {
         if (!mounted) return;
 
+        let hydratedSettings = loadedSettings;
+
         let registeredHotkey = loadedSettings.hotkey;
         try {
           registeredHotkey = await registerHotkeyCandidate(loadedSettings.hotkey);
@@ -255,10 +464,22 @@ export default function App() {
           registeredHotkey = lastValidHotkeyRef.current;
         }
 
-        const hydratedSettings =
-          registeredHotkey !== loadedSettings.hotkey
-            ? { ...loadedSettings, hotkey: registeredHotkey }
-            : loadedSettings;
+        if (registeredHotkey !== hydratedSettings.hotkey) {
+          hydratedSettings = {
+            ...hydratedSettings,
+            hotkey: registeredHotkey,
+          };
+        }
+
+        try {
+          await getCurrentWindow().setAlwaysOnTop(hydratedSettings.alwaysOnTop);
+        } catch (err) {
+          console.error("Failed to restore always on top:", err);
+          hydratedSettings = {
+            ...hydratedSettings,
+            alwaysOnTop: false,
+          };
+        }
 
         lastValidHotkeyRef.current = hydratedSettings.hotkey;
         uiSettingsRef.current = hydratedSettings;
@@ -272,7 +493,10 @@ export default function App() {
 
         await syncSettingsToBackend(hydratedSettings);
 
-        if (hydratedSettings.hotkey !== loadedSettings.hotkey) {
+        if (
+          hydratedSettings.hotkey !== loadedSettings.hotkey ||
+          hydratedSettings.alwaysOnTop !== loadedSettings.alwaysOnTop
+        ) {
           await saveSettings(hydratedSettings);
         }
       })
@@ -412,8 +636,10 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    document.documentElement.dataset.theme = settings.theme ?? "dark";
-  }, [settings.theme]);
+    const theme = settings.theme ?? "dark";
+    document.documentElement.dataset.theme = theme;
+    applyAccentTheme(settings.accentColor, theme);
+  }, [settings.accentColor, settings.theme]);
 
   const handleTabChange = (nextTab: Tab) => {
     setTab(nextTab);
@@ -437,6 +663,7 @@ export default function App() {
       await invoke("reset_settings");
       await clearSavedSettings();
       await invoke("set_autostart_enabled", { enabled: false }).catch(() => {});
+      await getCurrentWindow().setAlwaysOnTop(DEFAULT_SETTINGS.alwaysOnTop);
 
       lastValidHotkeyRef.current = DEFAULT_SETTINGS.hotkey;
       committedSettingsRef.current = DEFAULT_SETTINGS;
@@ -474,6 +701,8 @@ export default function App() {
             ? status.stopReason
             : null
         }
+        isAlwaysOnTop={settings.alwaysOnTop}
+        onToggleAlwaysOnTop={handleToggleAlwaysOnTop}
         onRequestClose={handleWindowClose}
       />
       {updateInfo && (
@@ -505,7 +734,14 @@ export default function App() {
           <SettingsPanel
             settings={settings}
             update={updateSettings}
+            running={status.running}
             appInfo={appInfo}
+            onSavePreset={handleSavePreset}
+            onApplyPreset={handleApplyPreset}
+            onUpdatePreset={handleUpdatePreset}
+            onRenamePreset={handleRenamePreset}
+            onDeletePreset={handleDeletePreset}
+            onToggleAlwaysOnTop={handleToggleAlwaysOnTop}
             onReset={handleResetSettings}
           />
         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import { canonicalizeHotkeyForBackend } from "./hotkeys";
 import {
   buildPresetSnapshot,
   createPresetDefinition,
+  MAX_PRESETS,
+  sanitizePresetName,
   type PresetId,
 } from "./settingsSchema";
 import {
@@ -35,7 +37,7 @@ const AdvancedPanelCompact = lazy(
 
 export type Tab = "simple" | "advanced" | "settings";
 
-const BACKEND_SETTINGS_SCHEMA_VERSION = 7;
+const BACKEND_SETTINGS_SCHEMA_VERSION = 6;
 const OPERATIONAL_SETTING_KEYS = new Set<string>(Object.keys(buildPresetSnapshot(DEFAULT_SETTINGS)));
 
 function getPanelSize(tab: Tab, settings: Settings, hasUpdate: boolean) {
@@ -287,6 +289,10 @@ export default function App() {
       return false;
     }
 
+    if (committedSettingsRef.current.presets.length >= MAX_PRESETS) {
+      return false;
+    }
+
     const preset = createPresetDefinition(name, committedSettingsRef.current);
     if (!preset.name) {
       return false;
@@ -375,8 +381,8 @@ export default function App() {
       return false;
     }
 
-    const trimmedName = name.trim();
-    if (!trimmedName) {
+    const sanitizedName = sanitizePresetName(name);
+    if (!sanitizedName) {
       return false;
     }
 
@@ -389,7 +395,7 @@ export default function App() {
       updated = true;
       return {
         ...preset,
-        name: trimmedName,
+        name: sanitizedName,
         updatedAt: new Date().toISOString(),
       };
     });

--- a/src/accentTheme.ts
+++ b/src/accentTheme.ts
@@ -1,0 +1,40 @@
+import type { Theme } from "./settingsSchema";
+
+type RGB = {
+  r: number;
+  g: number;
+  b: number;
+};
+
+function hexToRgb(hex: string): RGB {
+  const normalized = hex.replace("#", "");
+  const value = Number.parseInt(normalized, 16);
+
+  return {
+    r: (value >> 16) & 0xff,
+    g: (value >> 8) & 0xff,
+    b: value & 0xff,
+  };
+}
+
+function rgba({ r, g, b }: RGB, alpha: number) {
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function applyAccentTheme(accentColor: string, theme: Theme) {
+  const root = document.documentElement;
+  const rgb = hexToRgb(accentColor);
+  const accentAlpha = theme === "light" ? 0.9 : 0.75;
+  const strongAlpha = theme === "light" ? 1 : 0.92;
+  const softAlpha = theme === "light" ? 0.2 : 0.15;
+  const ringAlpha = theme === "light" ? 0.4 : 0.35;
+  const glowPrimaryAlpha = theme === "light" ? 0.16 : 0.2;
+  const glowSecondaryAlpha = theme === "light" ? 0.08 : 0.12;
+
+  root.style.setProperty("--accent-green", rgba(rgb, accentAlpha));
+  root.style.setProperty("--accent-green-strong", rgba(rgb, strongAlpha));
+  root.style.setProperty("--accent-green-soft", rgba(rgb, softAlpha));
+  root.style.setProperty("--accent-green-ring", rgba(rgb, ringAlpha));
+  root.style.setProperty("--accent-green-glow-1", rgba(rgb, glowPrimaryAlpha));
+  root.style.setProperty("--accent-green-glow-2", rgba(rgb, glowSecondaryAlpha));
+}

--- a/src/components/TitleBar.css
+++ b/src/components/TitleBar.css
@@ -33,10 +33,10 @@
 }
 
 .window-title-background[data-running="true"] .window-title {
-  color: #9ae7ae;
+  color: var(--accent-green-strong);
   text-shadow:
-    0 0 0.625rem rgba(74, 222, 128, 0.2),
-    0 0 1.125rem rgba(74, 222, 128, 0.12);
+    0 0 10px var(--accent-green-glow-1),
+    0 0 18px var(--accent-green-glow-2);
 }
 
 .settings-button {
@@ -150,12 +150,12 @@
 }
 
 .window-btn.active {
-  color: var(--accent-green);
+  color: var(--accent-green-strong);
   /* background: rgba(255, 255, 255, 0.08); */
 }
 
 .window-btn.active:hover {
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--accent-green-soft);
 }
 
 /* -- Title Flip Animation -- */

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,18 +1,28 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import type { Tab } from "../App";
 import "./TitleBar.css";
 
 const appWindow = getCurrentWindow();
 const DEFAULT_TITLE = "BlurAutoClicker";
 
-const handleMinimize = async () => await appWindow.minimize();
+async function handleMinimize() {
+  await appWindow.minimize();
+}
 
 interface Props {
   tab: Tab;
   setTab: (t: Tab) => void;
   running: boolean;
   stopReason?: string | null;
+  isAlwaysOnTop: boolean;
+  onToggleAlwaysOnTop: () => Promise<void>;
   onRequestClose: () => Promise<void>;
 }
 
@@ -26,7 +36,7 @@ type TabItem = {
   value: NavTab;
   label: string;
   color: string;
-  icon: (props: TabIconProps) => React.ReactNode;
+  icon: (props: TabIconProps) => ReactNode;
 };
 
 type TitleViewState = {
@@ -92,20 +102,10 @@ export default function TitleBar({
   setTab,
   running,
   stopReason,
+  isAlwaysOnTop,
+  onToggleAlwaysOnTop,
   onRequestClose,
 }: Props) {
-  const [isAlwaysOnTop, setIsAlwaysOnTop] = useState(false);
-
-  const toggleAlwaysOnTop = async () => {
-    try {
-      const newState = !isAlwaysOnTop;
-      await appWindow.setAlwaysOnTop(newState);
-      setIsAlwaysOnTop(newState);
-    } catch (err) {
-      console.error("Failed to set always on top:", err);
-    }
-  };
-
   return (
     <div
       className="window-title-background"
@@ -113,7 +113,7 @@ export default function TitleBar({
         {
           WebkitAppRegion: "drag",
           WebkitUserSelect: "none",
-        } as React.CSSProperties
+        } as CSSProperties
       }
       data-tauri-drag-region
       data-running={running}
@@ -123,7 +123,7 @@ export default function TitleBar({
           className="settings-button"
           data-active={tab === "settings"}
           onClick={() => setTab("settings")}
-          style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+          style={{ WebkitAppRegion: "no-drag" } as CSSProperties}
         >
           <svg
             className="settings-svg"
@@ -168,11 +168,13 @@ export default function TitleBar({
             alignItems: "center",
             gap: "4px",
             WebkitAppRegion: "no-drag",
-          } as React.CSSProperties
+          } as CSSProperties
         }
       >
         <WindowBtn
-          onClick={toggleAlwaysOnTop}
+          onClick={() => {
+            void onToggleAlwaysOnTop();
+          }}
           active={isAlwaysOnTop}
           title={isAlwaysOnTop ? "Disable Always on Top" : "Enable Always on Top"}
           label={
@@ -193,16 +195,22 @@ export default function TitleBar({
           }
         />
         <WindowBtn
-          onClick={handleMinimize}
+          onClick={() => {
+            void handleMinimize();
+          }}
           label={
             <svg width="10" height="2" viewBox="0 0 10 2" fill="none">
               <rect width="10" height="2" fill="currentColor" />
             </svg>
           }
+          title="Minimize"
         />
         <WindowBtn
-          onClick={onRequestClose}
+          onClick={() => {
+            void onRequestClose();
+          }}
           danger
+          title="Close"
           label={
             <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
               <path
@@ -305,7 +313,7 @@ function TabIconButton({
   onClick,
   color,
 }: {
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string;
   active: boolean;
   onClick: () => void;
@@ -322,7 +330,7 @@ function TabIconButton({
         {
           "--active-color": color,
           WebkitAppRegion: "no-drag",
-        } as React.CSSProperties
+        } as CSSProperties
       }
     >
       {icon}
@@ -338,7 +346,7 @@ function WindowBtn({
   title,
 }: {
   onClick: () => void;
-  label: React.ReactNode;
+  label: ReactNode;
   danger?: boolean;
   active?: boolean;
   title?: string;

--- a/src/components/panels/AdvancedPanelLayout.tsx
+++ b/src/components/panels/AdvancedPanelLayout.tsx
@@ -262,13 +262,13 @@ export default function AdvancedPanelLayout({
                   />
                 </div>
                 <div className="simple-seg-group">
-                  {(["Toggle", "Hold"] as const).map((m) => (
+                  {(["Toggle", "Hold"] as const).map((clickModeOption) => (
                     <button
-                      key={m}
-                      className={`simple-seg-btn ${settings.mode === m ? "active" : ""}`}
-                      onClick={() => update({ mode: m })}
+                      key={clickModeOption}
+                      className={`simple-seg-btn ${settings.mode === clickModeOption ? "active" : ""}`}
+                      onClick={() => update({ mode: clickModeOption })}
                     >
-                      {m}
+                      {clickModeOption}
                     </button>
                   ))}
                 </div>
@@ -276,13 +276,13 @@ export default function AdvancedPanelLayout({
               <div className="adv-row" style={{ marginTop: rowSpacing }}>
                 <span className="adv-label">Mouse Button</span>
                 <div className="simple-seg-group">
-                  {MOUSE_BUTTON_OPTIONS.map((button) => (
+                  {MOUSE_BUTTON_OPTIONS.map((mouseButtonOption) => (
                     <button
-                      key={button}
-                      className={`simple-seg-btn ${settings.mouseButton === button ? "active" : ""}`}
-                      onClick={() => update({ mouseButton: button })}
+                      key={mouseButtonOption}
+                      className={`simple-seg-btn ${settings.mouseButton === mouseButtonOption ? "active" : ""}`}
+                      onClick={() => update({ mouseButton: mouseButtonOption })}
                     >
-                      {button}
+                      {mouseButtonOption}
                     </button>
                   ))}
                 </div>
@@ -440,13 +440,13 @@ export default function AdvancedPanelLayout({
                       />
                       </div>
                       <div className="simple-seg-group">
-                        {TIME_LIMIT_UNIT_OPTIONS.map((unit) => (
+                        {TIME_LIMIT_UNIT_OPTIONS.map((timeLimitUnitOption) => (
                           <button
-                            key={unit}
-                            className={`simple-seg-btn ${settings.timeLimitUnit === unit ? "active" : ""}`}
-                            onClick={() => update({ timeLimitUnit: unit })}
+                            key={timeLimitUnitOption}
+                            className={`simple-seg-btn ${settings.timeLimitUnit === timeLimitUnitOption ? "active" : ""}`}
+                            onClick={() => update({ timeLimitUnit: timeLimitUnitOption })}
                           >
-                            {unit}
+                            {timeLimitUnitOption}
                           </button>
                         ))}
                       </div>
@@ -480,13 +480,13 @@ export default function AdvancedPanelLayout({
                     </p>
                   )}
                   <div className="adv-corner-grid">
-                    {(["tl", "tr", "bl", "br"] as const).map((c) => (
-                      <div key={c} className="adv-corner-box">
-                        <div className={`adv-arc adv-arc-${c}`} />
+                    {(["tl", "tr", "bl", "br"] as const).map((cornerKey) => (
+                      <div key={cornerKey} className="adv-corner-box">
+                        <div className={`adv-arc adv-arc-${cornerKey}`} />
                         <NumInput
-                          value={settings[CORNER_KEYS[c]]}
+                          value={settings[CORNER_KEYS[cornerKey]]}
                           onChange={(v) => {
-                            update({ [CORNER_KEYS[c]]: v });
+                            update({ [CORNER_KEYS[cornerKey]]: v });
                           }}
                           min={SETTINGS_LIMITS.stopBoundary.min}
                           max={SETTINGS_LIMITS.stopBoundary.max}
@@ -520,13 +520,13 @@ export default function AdvancedPanelLayout({
                     </p>
                   )}
                   <div className="adv-corner-grid">
-                    {(["top", "right", "left", "bottom"] as const).map((e) => (
-                      <div key={e} className="adv-corner-box">
-                        <div className={`adv-edge-bar adv-edge-bar-${e}`} />
+                    {(["top", "right", "left", "bottom"] as const).map((edgeSide) => (
+                      <div key={edgeSide} className="adv-corner-box">
+                        <div className={`adv-edge-bar adv-edge-bar-${edgeSide}`} />
                         <NumInput
-                          value={settings[EDGE_KEYS[e]]}
+                          value={settings[EDGE_KEYS[edgeSide]]}
                           onChange={(v) => {
-                            update({ [EDGE_KEYS[e]]: v });
+                            update({ [EDGE_KEYS[edgeSide]]: v });
                           }}
                           min={SETTINGS_LIMITS.stopBoundary.min}
                           max={SETTINGS_LIMITS.stopBoundary.max}
@@ -671,13 +671,13 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <div className="simple-seg-group">
-                {(["Toggle", "Hold"] as const).map((m) => (
+                {(["Toggle", "Hold"] as const).map((clickModeOption) => (
                   <button
-                    key={m}
-                    className={`simple-seg-btn ${settings.mode === m ? "active" : ""}`}
-                    onClick={() => update({ mode: m })}
+                    key={clickModeOption}
+                    className={`simple-seg-btn ${settings.mode === clickModeOption ? "active" : ""}`}
+                    onClick={() => update({ mode: clickModeOption })}
                   >
-                    {m}
+                    {clickModeOption}
                   </button>
                 ))}
               </div>
@@ -685,13 +685,13 @@ export default function AdvancedPanelLayout({
             <div className="adv-row" style={{ marginTop: rowSpacing }}>
               <span className="adv-label">Mouse Button</span>
               <div className="simple-seg-group">
-                {MOUSE_BUTTON_OPTIONS.map((button) => (
+                {MOUSE_BUTTON_OPTIONS.map((mouseButtonOption) => (
                   <button
-                    key={button}
-                    className={`simple-seg-btn ${settings.mouseButton === button ? "active" : ""}`}
-                    onClick={() => update({ mouseButton: button })}
+                    key={mouseButtonOption}
+                    className={`simple-seg-btn ${settings.mouseButton === mouseButtonOption ? "active" : ""}`}
+                    onClick={() => update({ mouseButton: mouseButtonOption })}
                   >
-                    {button}
+                    {mouseButtonOption}
                   </button>
                 ))}
               </div>
@@ -845,13 +845,13 @@ export default function AdvancedPanelLayout({
                       />
                     </div>
                     <div className="simple-seg-group">
-                      {TIME_LIMIT_UNIT_OPTIONS.map((unit) => (
+                      {TIME_LIMIT_UNIT_OPTIONS.map((timeLimitUnitOption) => (
                         <button
-                          key={unit}
-                          className={`simple-seg-btn ${settings.timeLimitUnit === unit ? "active" : ""}`}
-                          onClick={() => update({ timeLimitUnit: unit })}
+                          key={timeLimitUnitOption}
+                          className={`simple-seg-btn ${settings.timeLimitUnit === timeLimitUnitOption ? "active" : ""}`}
+                          onClick={() => update({ timeLimitUnit: timeLimitUnitOption })}
                         >
-                          {unit}
+                          {timeLimitUnitOption}
                         </button>
                       ))}
                     </div>
@@ -928,13 +928,13 @@ export default function AdvancedPanelLayout({
               <Disableable enabled={settings.cornerStopEnabled}>
                 <div className={featureBodyClass}>
                   <div className="adv-corner-grid">
-                    {(["tl", "tr", "bl", "br"] as const).map((c) => (
-                      <div key={c} className="adv-corner-box">
-                        <div className={`adv-arc adv-arc-${c}`} />
+                    {(["tl", "tr", "bl", "br"] as const).map((cornerKey) => (
+                      <div key={cornerKey} className="adv-corner-box">
+                        <div className={`adv-arc adv-arc-${cornerKey}`} />
                         <NumInput
-                          value={settings[CORNER_KEYS[c]]}
+                          value={settings[CORNER_KEYS[cornerKey]]}
                           onChange={(v) => {
-                            update({ [CORNER_KEYS[c]]: v });
+                            update({ [CORNER_KEYS[cornerKey]]: v });
                           }}
                           min={SETTINGS_LIMITS.stopBoundary.min}
                           max={SETTINGS_LIMITS.stopBoundary.max}
@@ -962,13 +962,13 @@ export default function AdvancedPanelLayout({
               <Disableable enabled={settings.edgeStopEnabled}>
                 <div className={featureBodyClass}>
                   <div className="adv-corner-grid">
-                    {(["top", "right", "left", "bottom"] as const).map((e) => (
-                      <div key={e} className="adv-corner-box">
-                        <div className={`adv-edge-bar adv-edge-bar-${e}`} />
+                    {(["top", "right", "left", "bottom"] as const).map((edgeSide) => (
+                      <div key={edgeSide} className="adv-corner-box">
+                        <div className={`adv-edge-bar adv-edge-bar-${edgeSide}`} />
                         <NumInput
-                          value={settings[EDGE_KEYS[e]]}
+                          value={settings[EDGE_KEYS[edgeSide]]}
                           onChange={(v) => {
-                            update({ [EDGE_KEYS[e]]: v });
+                            update({ [EDGE_KEYS[edgeSide]]: v });
                           }}
                           min={SETTINGS_LIMITS.stopBoundary.min}
                           max={SETTINGS_LIMITS.stopBoundary.max}

--- a/src/components/panels/AdvancedPanelLayout.tsx
+++ b/src/components/panels/AdvancedPanelLayout.tsx
@@ -10,8 +10,13 @@ import {
   type ReactNode,
 } from "react";
 import type { Settings } from "../../store";
+import {
+  CLICK_INTERVAL_OPTIONS,
+  MOUSE_BUTTON_OPTIONS,
+  SETTINGS_LIMITS,
+  TIME_LIMIT_UNIT_OPTIONS,
+} from "../../settingsSchema";
 import HotkeyCaptureInput from "../HotkeyCaptureInput";
-import React from "react";
 
 interface Props {
   settings: Settings;
@@ -30,7 +35,7 @@ function ToggleBtn({
   onChange: (v: boolean) => void;
   disabled?: boolean;
 }) {
-  React.useEffect(() => {
+  useEffect(() => {
     if (disabled && value) {
       onChange(false);
     }
@@ -222,21 +227,21 @@ export default function AdvancedPanelLayout({
               <div className="adv-row">
                 <div className="adv-numbox-sm">
                   <NumInput
-                    value={settings.clickSpeed}
-                    onChange={(v) => update({ clickSpeed: v })}
-                    min={1}
-                    max={500}
-                  />
-                </div>
+                        value={settings.clickSpeed}
+                        onChange={(v) => update({ clickSpeed: v })}
+                        min={SETTINGS_LIMITS.clickSpeed.min}
+                        max={SETTINGS_LIMITS.clickSpeed.max}
+                      />
+                    </div>
                 <span className="adv-label">Clicks Per</span>
                 <div className="simple-seg-group">
-                  {(["s", "m", "h", "d"] as const).map((u) => (
+                  {CLICK_INTERVAL_OPTIONS.map((option) => (
                     <button
-                      key={u}
-                      className={`simple-seg-btn ${settings.clickInterval === u ? "active" : ""}`}
-                      onClick={() => update({ clickInterval: u })}
+                      key={option.value}
+                      className={`simple-seg-btn ${settings.clickInterval === option.value ? "active" : ""}`}
+                      onClick={() => update({ clickInterval: option.value })}
                     >
-                      {u}
+                      {option.value}
                     </button>
                   ))}
                 </div>
@@ -271,13 +276,13 @@ export default function AdvancedPanelLayout({
               <div className="adv-row" style={{ marginTop: rowSpacing }}>
                 <span className="adv-label">Mouse Button</span>
                 <div className="simple-seg-group">
-                  {(["Left", "Middle", "Right"] as const).map((b) => (
+                  {MOUSE_BUTTON_OPTIONS.map((button) => (
                     <button
-                      key={b}
-                      className={`simple-seg-btn ${settings.mouseButton === b ? "active" : ""}`}
-                      onClick={() => update({ mouseButton: b })}
+                      key={button}
+                      className={`simple-seg-btn ${settings.mouseButton === button ? "active" : ""}`}
+                      onClick={() => update({ mouseButton: button })}
                     >
-                      {b}
+                      {button}
                     </button>
                   ))}
                 </div>
@@ -293,8 +298,8 @@ export default function AdvancedPanelLayout({
                       <NumInput
                         value={settings.dutyCycle}
                         onChange={(v) => update({ dutyCycle: v })}
-                        min={0}
-                        max={100}
+                        min={SETTINGS_LIMITS.dutyCycle.min}
+                        max={SETTINGS_LIMITS.dutyCycle.max}
                       />
                       <span className="adv-unit">%</span>
                     </div>
@@ -316,8 +321,8 @@ export default function AdvancedPanelLayout({
                       <NumInput
                         value={settings.speedVariation}
                         onChange={(v) => update({ speedVariation: v })}
-                        min={0}
-                        max={200}
+                        min={SETTINGS_LIMITS.speedVariation.min}
+                        max={SETTINGS_LIMITS.speedVariation.max}
                       />
                       <span className="adv-unit">%</span>
                     </div>
@@ -405,7 +410,7 @@ export default function AdvancedPanelLayout({
                       <NumInput
                         value={settings.clickLimit}
                         onChange={(v) => update({ clickLimit: v })}
-                        min={1}
+                        min={SETTINGS_LIMITS.clickLimit.min}
                         style={{ width: "89px", textAlign: "right" }}
                       />
                       <span className="adv-unit">clicks</span>
@@ -428,20 +433,20 @@ export default function AdvancedPanelLayout({
                     <div className="adv-row" style={{ gap: 6 }}>
                       <div className="adv-numbox-sm">
                         <NumInput
-                          value={settings.timeLimit}
-                          onChange={(v) => update({ timeLimit: v })}
-                          min={1}
-                          style={{ width: "38px", textAlign: "right" }}
-                        />
+                        value={settings.timeLimit}
+                        onChange={(v) => update({ timeLimit: v })}
+                        min={SETTINGS_LIMITS.timeLimit.min}
+                        style={{ width: "38px", textAlign: "right" }}
+                      />
                       </div>
                       <div className="simple-seg-group">
-                        {(["s", "m", "h"] as const).map((u) => (
+                        {TIME_LIMIT_UNIT_OPTIONS.map((unit) => (
                           <button
-                            key={u}
-                            className={`simple-seg-btn ${settings.timeLimitUnit === u ? "active" : ""}`}
-                            onClick={() => update({ timeLimitUnit: u })}
+                            key={unit}
+                            className={`simple-seg-btn ${settings.timeLimitUnit === unit ? "active" : ""}`}
+                            onClick={() => update({ timeLimitUnit: unit })}
                           >
-                            {u}
+                            {unit}
                           </button>
                         ))}
                       </div>
@@ -483,8 +488,8 @@ export default function AdvancedPanelLayout({
                           onChange={(v) => {
                             update({ [CORNER_KEYS[c]]: v });
                           }}
-                          min={0}
-                          max={999}
+                          min={SETTINGS_LIMITS.stopBoundary.min}
+                          max={SETTINGS_LIMITS.stopBoundary.max}
                           style={{ width: "28px", textAlign: "right" }}
                         />
                         <span className="adv-unit">px</span>
@@ -523,8 +528,8 @@ export default function AdvancedPanelLayout({
                           onChange={(v) => {
                             update({ [EDGE_KEYS[e]]: v });
                           }}
-                          min={0}
-                          max={999}
+                          min={SETTINGS_LIMITS.stopBoundary.min}
+                          max={SETTINGS_LIMITS.stopBoundary.max}
                           style={{ width: "28px", textAlign: "right" }}
                         />
                         <span className="adv-unit">px</span>
@@ -580,7 +585,7 @@ export default function AdvancedPanelLayout({
                         <NumInput
                           value={settings.positionX}
                           onChange={(v) => update({ positionX: v })}
-                          min={0}
+                          min={SETTINGS_LIMITS.position.min}
                           style={{ width: "37px" }}
                         />
                       </div>
@@ -597,7 +602,7 @@ export default function AdvancedPanelLayout({
                         <NumInput
                           value={settings.positionY}
                           onChange={(v) => update({ positionY: v })}
-                          min={0}
+                          min={SETTINGS_LIMITS.position.min}
                           style={{ width: "37px" }}
                         />
                       </div>
@@ -633,19 +638,19 @@ export default function AdvancedPanelLayout({
                 <NumInput
                   value={settings.clickSpeed}
                   onChange={(v) => update({ clickSpeed: v })}
-                  min={1}
-                  max={500}
+                  min={SETTINGS_LIMITS.clickSpeed.min}
+                  max={SETTINGS_LIMITS.clickSpeed.max}
                 />
               </div>
               <span className="adv-label">Clicks Per</span>
               <div className="simple-seg-group">
-                {(["s", "m", "h", "d"] as const).map((u) => (
+                {CLICK_INTERVAL_OPTIONS.map((option) => (
                   <button
-                    key={u}
-                    className={`simple-seg-btn ${settings.clickInterval === u ? "active" : ""}`}
-                    onClick={() => update({ clickInterval: u })}
+                    key={option.value}
+                    className={`simple-seg-btn ${settings.clickInterval === option.value ? "active" : ""}`}
+                    onClick={() => update({ clickInterval: option.value })}
                   >
-                    {u}
+                    {option.value}
                   </button>
                 ))}
               </div>
@@ -680,13 +685,13 @@ export default function AdvancedPanelLayout({
             <div className="adv-row" style={{ marginTop: rowSpacing }}>
               <span className="adv-label">Mouse Button</span>
               <div className="simple-seg-group">
-                {(["Left", "Middle", "Right"] as const).map((b) => (
+                {MOUSE_BUTTON_OPTIONS.map((button) => (
                   <button
-                    key={b}
-                    className={`simple-seg-btn ${settings.mouseButton === b ? "active" : ""}`}
-                    onClick={() => update({ mouseButton: b })}
+                    key={button}
+                    className={`simple-seg-btn ${settings.mouseButton === button ? "active" : ""}`}
+                    onClick={() => update({ mouseButton: button })}
                   >
-                    {b}
+                    {button}
                   </button>
                 ))}
               </div>
@@ -757,11 +762,11 @@ export default function AdvancedPanelLayout({
                   >
                     <span className="adv-unit adv-axis-label">X</span>
                     <NumInput
-                      value={settings.positionX}
-                      onChange={(v) => update({ positionX: v })}
-                      min={0}
-                      style={{ width: "32px" }}
-                    />
+                        value={settings.positionX}
+                        onChange={(v) => update({ positionX: v })}
+                        min={SETTINGS_LIMITS.position.min}
+                        style={{ width: "32px" }}
+                      />
                   </div>
                   <div
                     className="adv-numbox-sm"
@@ -769,11 +774,11 @@ export default function AdvancedPanelLayout({
                   >
                     <span className="adv-unit adv-axis-label">Y</span>
                     <NumInput
-                      value={settings.positionY}
-                      onChange={(v) => update({ positionY: v })}
-                      min={0}
-                      style={{ width: "32px" }}
-                    />
+                        value={settings.positionY}
+                        onChange={(v) => update({ positionY: v })}
+                        min={SETTINGS_LIMITS.position.min}
+                        style={{ width: "32px" }}
+                      />
                   </div>
                   <button
                     className="adv-pick-btn adv-pick-btn-inline"
@@ -808,8 +813,8 @@ export default function AdvancedPanelLayout({
                       <NumInput
                         value={settings.clickLimit}
                         onChange={(v) => update({ clickLimit: v })}
-                        min={1}
-                        max={10000000}
+                        min={SETTINGS_LIMITS.clickLimit.min}
+                        max={SETTINGS_LIMITS.clickLimit.max}
                         style={{ width: "72px", textAlign: "right" }}
                       />
                       <span className="adv-unit">clicks</span>
@@ -835,18 +840,18 @@ export default function AdvancedPanelLayout({
                       <NumInput
                         value={settings.timeLimit}
                         onChange={(v) => update({ timeLimit: v })}
-                        min={1}
+                        min={SETTINGS_LIMITS.timeLimit.min}
                         style={{ width: "32px", textAlign: "right" }}
                       />
                     </div>
                     <div className="simple-seg-group">
-                      {(["s", "m", "h"] as const).map((u) => (
+                      {TIME_LIMIT_UNIT_OPTIONS.map((unit) => (
                         <button
-                          key={u}
-                          className={`simple-seg-btn ${settings.timeLimitUnit === u ? "active" : ""}`}
-                          onClick={() => update({ timeLimitUnit: u })}
+                          key={unit}
+                          className={`simple-seg-btn ${settings.timeLimitUnit === unit ? "active" : ""}`}
+                          onClick={() => update({ timeLimitUnit: unit })}
                         >
-                          {u}
+                          {unit}
                         </button>
                       ))}
                     </div>
@@ -870,13 +875,13 @@ export default function AdvancedPanelLayout({
                     <div className="adv-minmax">
                       <div className="adv-numbox-sm">
                         <NumInput
-                          value={settings.dutyCycle}
-                          onChange={(v) => update({ dutyCycle: v })}
-                          min={0}
-                          max={200}
-                        />
-                        <span className="adv-unit">%</span>
-                      </div>
+                        value={settings.dutyCycle}
+                        onChange={(v) => update({ dutyCycle: v })}
+                        min={SETTINGS_LIMITS.dutyCycle.min}
+                        max={SETTINGS_LIMITS.dutyCycle.max}
+                      />
+                      <span className="adv-unit">%</span>
+                    </div>
                     </div>
                   </div>
                 </div>
@@ -899,8 +904,8 @@ export default function AdvancedPanelLayout({
                       <NumInput
                         value={settings.speedVariation}
                         onChange={(v) => update({ speedVariation: v })}
-                        min={0}
-                        max={200}
+                        min={SETTINGS_LIMITS.speedVariation.min}
+                        max={SETTINGS_LIMITS.speedVariation.max}
                       />
                       <span className="adv-unit">%</span>
                     </div>
@@ -931,8 +936,8 @@ export default function AdvancedPanelLayout({
                           onChange={(v) => {
                             update({ [CORNER_KEYS[c]]: v });
                           }}
-                          min={0}
-                          max={999}
+                          min={SETTINGS_LIMITS.stopBoundary.min}
+                          max={SETTINGS_LIMITS.stopBoundary.max}
                           style={{ width: "28px", textAlign: "right" }}
                         />
                         <span className="adv-unit">px</span>
@@ -965,8 +970,8 @@ export default function AdvancedPanelLayout({
                           onChange={(v) => {
                             update({ [EDGE_KEYS[e]]: v });
                           }}
-                          min={0}
-                          max={999}
+                          min={SETTINGS_LIMITS.stopBoundary.min}
+                          max={SETTINGS_LIMITS.stopBoundary.max}
                           style={{ width: "28px", textAlign: "right" }}
                         />
                         <span className="adv-unit">px</span>

--- a/src/components/panels/SettingsPanel.css
+++ b/src/components/panels/SettingsPanel.css
@@ -1,7 +1,8 @@
 .settings-panel {
   display: flex;
   flex-direction: column;
-  padding: 0.25rem 1.25rem;
+  gap: 0.25rem;
+  padding: 0.25rem 1.25rem 1rem;
   height: 100%;
   overflow-y: auto;
 }
@@ -12,11 +13,11 @@
   border-radius: 0.5rem;
 }
 
-
 .settings-panel::-webkit-scrollbar-thumb {
   background: var(--text-dim);
   border-radius: 0.25rem;
 }
+
 .settings-panel::-webkit-scrollbar-thumb:hover {
   background: #777;
 }
@@ -30,6 +31,11 @@
   padding: 0.75rem 0;
 }
 
+.settings-row--stacked {
+  flex-direction: column;
+  align-items: stretch;
+}
+
 .settings-divider {
   width: 100%;
   height: 1px;
@@ -38,7 +44,7 @@
 }
 
 .settings-label {
-  font-family: 'DMSans', sans-serif;
+  font-family: var(--font-family-base);
   font-size: 1rem;
   font-weight: var(--font-weight-md);
   letter-spacing: -0.02em;
@@ -54,21 +60,21 @@
 }
 
 .settings-sublabel {
-  font-family: 'DMSans', sans-serif;
+  font-family: var(--font-family-base);
   font-size: 0.75rem;
   font-weight: var(--font-weight-li);
   color: var(--text-muted);
 }
 
 .settings-value {
-  font-family: 'DMSans', sans-serif;
+  font-family: var(--font-family-base);
   font-size: 0.875rem;
   font-weight: var(--font-weight-md);
   color: var(--text-muted);
 }
 
-.settings-value--green {
-  color: var(--accent-green);
+.settings-value--mono {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
 }
 
 .settings-seg-group {
@@ -82,7 +88,7 @@
 }
 
 .settings-seg-btn {
-  font-family: 'DMSans', sans-serif;
+  font-family: var(--font-family-base);
   font-size: 0.875rem;
   font-weight: var(--font-weight-md);
   padding: 0.3125rem 0.75rem;
@@ -108,22 +114,73 @@
   cursor: not-allowed;
 }
 
-.settings-btn-danger {
-  font-family: 'DMSans', sans-serif;
+.settings-btn-primary,
+.settings-btn-secondary,
+.settings-btn-danger,
+.settings-btn-quiet {
+  font-family: var(--font-family-base);
   font-size: 0.875rem;
   font-weight: var(--font-weight-md);
-  padding: 0.3125rem 0.875rem;
+  padding: 0.4375rem 0.75rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.settings-btn-primary {
+  background: var(--accent-green-soft);
+  border: 1px solid var(--accent-green-ring);
+  color: var(--accent-green-strong);
+}
+
+.settings-btn-primary:hover {
+  background: var(--accent-green-soft);
+  border-color: var(--accent-green);
+}
+
+.settings-btn-secondary,
+.settings-btn-quiet,
+.settings-btn-danger {
   background: transparent;
   border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
+}
+
+.settings-btn-secondary {
+  color: var(--text-primary);
+}
+
+.settings-btn-secondary:hover,
+.settings-btn-quiet:hover {
+  background: var(--bg-elevated);
+  border-color: var(--border-focus);
+}
+
+.settings-btn-quiet {
+  color: var(--text-muted);
+}
+
+.settings-btn-danger {
   color: var(--accent-red);
-  cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease;
 }
 
 .settings-btn-danger:hover {
   background: rgba(255, 115, 106, 0.1);
   border-color: var(--accent-red);
+}
+
+.settings-btn-danger--compact {
+  padding-inline: 10px;
+}
+
+.settings-btn-primary:disabled,
+.settings-btn-secondary:disabled,
+.settings-btn-danger:disabled,
+.settings-btn-quiet:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .settings-wrapper {
@@ -140,14 +197,138 @@
   height: 10vb;
   background: linear-gradient(to bottom, transparent, var(--bg-base));
   pointer-events: none;
-}
-
-.settings-fade {
   transition: opacity 0.3s ease;
 }
 
 .settings-fade--hidden {
   opacity: 0;
+}
+
+.settings-note {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.settings-color-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.settings-color-picker {
+  width: 40px;
+  height: 40px;
+  padding: 4px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  cursor: pointer;
+}
+
+.settings-color-picker input {
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.preset-compose {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.preset-name-input,
+.preset-rename-input {
+  min-width: 0;
+  flex: 1;
+  padding: 9px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.preset-name-input::placeholder,
+.preset-rename-input::placeholder {
+  color: var(--text-dim);
+}
+
+.preset-name-input:focus,
+.preset-rename-input:focus {
+  border-color: var(--accent-green-ring);
+}
+
+.preset-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.preset-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  padding: 12px;
+}
+
+.preset-card--active {
+  border-color: var(--accent-green-ring);
+  box-shadow: inset 0 0 0 1px var(--accent-green-soft);
+}
+
+.preset-card-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.preset-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.preset-name {
+  font-size: 15px;
+  font-weight: var(--font-weight-md);
+  color: var(--text-primary);
+}
+
+.preset-badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.preset-badge {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--bg-input);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: var(--font-weight-md);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.preset-badge--active {
+  background: var(--accent-green-soft);
+  color: var(--accent-green-strong);
+}
+
+.preset-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: flex-start;
 }
 
 /* -- Social Links -- */
@@ -211,17 +392,16 @@
 }
 
 .social-icon--kofi:hover {
-  color: #72A5F2;
-  outline: 2px solid #72A5F2;
+  color: #72a5f2;
+  border-color: #72a5f2;
   background: #202020;
 }
 
 .social-icon--patreon:hover {
-  color: #FF424D;
+  color: #ff424d;
   border-color: rgba(255, 66, 77, 0.4);
   background: rgba(255, 66, 77, 0.08);
 }
-
 
 /* -- Usage Stats -- */
 
@@ -236,6 +416,7 @@
   gap: 0.25rem 1rem;
   padding: 0.25rem 0 0.5rem;
 }
+
 
 .stats-cell {
   display: flex;
@@ -267,6 +448,7 @@
   border-top: 1px solid var(--border-subtle);
   margin-top: 0.25rem;
 }
+
 
 .stats-empty {
   font-size: 0.75rem;

--- a/src/components/panels/SettingsPanel.tsx
+++ b/src/components/panels/SettingsPanel.tsx
@@ -1,8 +1,17 @@
 import "./SettingsPanel.css";
-import type { AppInfo, Settings } from "../../store";
+import type {
+  AppInfo,
+  PresetDefinition,
+  PresetId,
+  Settings,
+} from "../../store";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-shell";
+import {
+  DEFAULT_ACCENT_COLOR,
+  PRESET_NAME_MAX_LENGTH,
+} from "../../settingsSchema";
 
 interface CumulativeStats {
   totalClicks: number;
@@ -14,7 +23,14 @@ interface CumulativeStats {
 interface Props {
   settings: Settings;
   update: (patch: Partial<Settings>) => void;
+  running: boolean;
   appInfo: AppInfo;
+  onSavePreset: (name: string) => boolean;
+  onApplyPreset: (presetId: PresetId) => boolean;
+  onUpdatePreset: (presetId: PresetId) => boolean;
+  onRenamePreset: (presetId: PresetId, name: string) => boolean;
+  onDeletePreset: (presetId: PresetId) => boolean;
+  onToggleAlwaysOnTop: () => Promise<void>;
   onReset: () => Promise<void>;
 }
 
@@ -42,17 +58,126 @@ function formatCpu(cpu: number): string {
   return `${cpu.toFixed(1)}%`;
 }
 
+function PresetRow({
+  preset,
+  isActive,
+  isEditing,
+  running,
+  renameDraft,
+  onRenameDraftChange,
+  onStartRename,
+  onCancelRename,
+  onCommitRename,
+  onApply,
+  onUpdatePreset,
+  onDeletePreset,
+}: {
+  preset: PresetDefinition;
+  isActive: boolean;
+  isEditing: boolean;
+  running: boolean;
+  renameDraft: string;
+  onRenameDraftChange: (value: string) => void;
+  onStartRename: () => void;
+  onCancelRename: () => void;
+  onCommitRename: () => void;
+  onApply: () => void;
+  onUpdatePreset: () => void;
+  onDeletePreset: () => void;
+}) {
+  return (
+    <div className={`preset-card ${isActive ? "preset-card--active" : ""}`}>
+      <div className="preset-card-head">
+        <div className="preset-card-meta">
+          {isEditing ? (
+            <input
+              className="preset-rename-input"
+              value={renameDraft}
+              maxLength={PRESET_NAME_MAX_LENGTH}
+              onChange={(event) => onRenameDraftChange(event.target.value)}
+            />
+          ) : (
+            <span className="preset-name">{preset.name}</span>
+          )}
+          <div className="preset-badges">
+            {isActive && <span className="preset-badge preset-badge--active">Active</span>}
+            <span className="preset-badge">
+              {new Date(preset.updatedAt).toLocaleDateString()}
+            </span>
+          </div>
+        </div>
+        <div className="preset-actions">
+          {isEditing ? (
+            <>
+              <button
+                className="settings-btn-secondary"
+                onClick={onCommitRename}
+                disabled={running}
+              >
+                Save
+              </button>
+              <button className="settings-btn-quiet" onClick={onCancelRename}>
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                className="settings-btn-primary"
+                onClick={onApply}
+                disabled={running}
+              >
+                Apply
+              </button>
+              <button
+                className="settings-btn-secondary"
+                onClick={onUpdatePreset}
+                disabled={running}
+              >
+                Update
+              </button>
+              <button
+                className="settings-btn-secondary"
+                onClick={onStartRename}
+                disabled={running}
+              >
+                Rename
+              </button>
+              <button
+                className="settings-btn-danger settings-btn-danger--compact"
+                onClick={onDeletePreset}
+                disabled={running}
+              >
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function SettingsPanel({
   settings,
   update,
+  running,
   appInfo,
+  onSavePreset,
+  onApplyPreset,
+  onUpdatePreset,
+  onRenamePreset,
+  onDeletePreset,
+  onToggleAlwaysOnTop,
   onReset,
 }: Props) {
   const [resetting, setResetting] = useState(false);
-  // const [resettingStats, setResettingStats] = useState(false);
   const [stats, setStats] = useState<CumulativeStats | null>(null);
   const [atBottom, setAtBottom] = useState(false);
   const [autostartEnabled, setAutostartEnabled] = useState<boolean | null>(null);
+  const [newPresetName, setNewPresetName] = useState("");
+  const [editingPresetId, setEditingPresetId] = useState<PresetId | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
 
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -69,6 +194,36 @@ export default function SettingsPanel({
     const el = panelRef.current;
     if (!el) return;
     setAtBottom(el.scrollTop + el.clientHeight >= el.scrollHeight - 2);
+  };
+
+  const handleSavePreset = () => {
+    if (onSavePreset(newPresetName)) {
+      setNewPresetName("");
+    }
+  };
+
+  const handleStartRename = (preset: PresetDefinition) => {
+    setEditingPresetId(preset.id);
+    setRenameDraft(preset.name);
+  };
+
+  const handleCommitRename = () => {
+    if (!editingPresetId) {
+      return;
+    }
+
+    if (onRenamePreset(editingPresetId, renameDraft)) {
+      setEditingPresetId(null);
+      setRenameDraft("");
+    }
+  };
+
+  const handleAlwaysOnTopChange = (nextValue: boolean) => {
+    if (settings.alwaysOnTop === nextValue) {
+      return;
+    }
+
+    void onToggleAlwaysOnTop();
   };
 
   const hasStats = stats !== null && stats.totalSessions > 0;
@@ -153,15 +308,12 @@ export default function SettingsPanel({
           </div>
         </div>
 
-        {/* <div className="settings-divider" /> */}
         <div className="settings-row">
           <span className="settings-label">Version</span>
           <span className="settings-value">v{appInfo.version}</span>
         </div>
 
         <div className="settings-divider" />
-
-        {/* -- Your Usage Data -- */}
 
         <div className="settings-row">
           <div className="settings-label-group">
@@ -170,48 +322,30 @@ export default function SettingsPanel({
               Your personal clicker stats, tracked locally.
             </span>
           </div>
-          {/* <button
-            className="settings-btn-danger"
-            onClick={() => {
-              setResettingStats(true);
-              invoke<CumulativeStats>("reset_stats")
-                .then(setStats)
-                .finally(() => setResettingStats(false));
-            }}
-          >
-            {resettingStats ? "Clearing..." : "Clear"}
-          </button> */}
-          {/* TODO: BUTTON DISABLED FOR NOW UNTIL I MAKE A CONFIRMATION PROMPT */}
         </div>
         {hasStats ? (
-          <>
-            <div className="stats-grid">
-              <div className="stats-cell">
-                <span className="stats-cell-label">Total Clicks</span>
-                <span className="stats-cell-value">
-                  {formatNumber(stats.totalClicks)}
-                </span>
-              </div>
-              <div className="stats-cell">
-                <span className="stats-cell-label">
-                  Total Time spent clicking
-                </span>
-                <span className="stats-cell-value">
-                  {formatTime(stats.totalTimeSecs)}
-                </span>
-              </div>
-              <div className="stats-cell">
-                <span className="stats-cell-label">CPU Usage avg</span>
-                <span className="stats-cell-value">
-                  {formatCpu(stats.avgCpu)}
-                </span>
-              </div>
-              <div className="stats-cell">
-                <span className="stats-cell-label">Sessions</span>
-                <span className="stats-cell-value">{stats.totalSessions}</span>
-              </div>
+          <div className="stats-grid">
+            <div className="stats-cell">
+              <span className="stats-cell-label">Total Clicks</span>
+              <span className="stats-cell-value">
+                {formatNumber(stats.totalClicks)}
+              </span>
             </div>
-          </>
+            <div className="stats-cell">
+              <span className="stats-cell-label">Total Time Spent Clicking</span>
+              <span className="stats-cell-value">
+                {formatTime(stats.totalTimeSecs)}
+              </span>
+            </div>
+            <div className="stats-cell">
+              <span className="stats-cell-label">CPU Usage Avg</span>
+              <span className="stats-cell-value">{formatCpu(stats.avgCpu)}</span>
+            </div>
+            <div className="stats-cell">
+              <span className="stats-cell-label">Sessions</span>
+              <span className="stats-cell-value">{stats.totalSessions}</span>
+            </div>
+          </div>
         ) : (
           <div className="stats-empty">No runs recorded yet</div>
         )}
@@ -220,19 +354,39 @@ export default function SettingsPanel({
 
         <div className="settings-row">
           <div className="settings-label-group">
-            <span className="settings-label">Stop Hitbox Overlay</span>
+            <span className="settings-label">Always on Top</span>
             <span className="settings-sublabel">
-              Toggles whether the stop hitbox overlay is shown.
+              Keep the app pinned above other windows.
             </span>
           </div>
           <div className="settings-seg-group">
-            {["On", "Off"].map((o) => (
+            {["On", "Off"].map((option) => (
               <button
-                key={o}
-                className={`settings-seg-btn ${(settings.showStopOverlay ? "On" : "Off") === o ? "active" : ""}`}
-                onClick={() => update({ showStopOverlay: o === "On" })}
+                key={option}
+                className={`settings-seg-btn ${(settings.alwaysOnTop ? "On" : "Off") === option ? "active" : ""}`}
+                onClick={() => handleAlwaysOnTopChange(option === "On")}
               >
-                {o}
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="settings-row">
+          <div className="settings-label-group">
+            <span className="settings-label">Stop Hitbox Overlay</span>
+            <span className="settings-sublabel">
+              Toggle the stop-zone overlay preview.
+            </span>
+          </div>
+          <div className="settings-seg-group">
+            {["On", "Off"].map((option) => (
+              <button
+                key={option}
+                className={`settings-seg-btn ${(settings.showStopOverlay ? "On" : "Off") === option ? "active" : ""}`}
+                onClick={() => update({ showStopOverlay: option === "On" })}
+              >
+                {option}
               </button>
             ))}
           </div>
@@ -242,17 +396,17 @@ export default function SettingsPanel({
           <div className="settings-label-group">
             <span className="settings-label">Stop Reason Alert</span>
             <span className="settings-sublabel">
-              Shows why the clicker stopped in the title bar.
+              Show why the clicker stopped in the title bar.
             </span>
           </div>
           <div className="settings-seg-group">
-            {["On", "Off"].map((o) => (
+            {["On", "Off"].map((option) => (
               <button
-                key={o}
-                className={`settings-seg-btn ${(settings.showStopReason ? "On" : "Off") === o ? "active" : ""}`}
-                onClick={() => update({ showStopReason: o === "On" })}
+                key={option}
+                className={`settings-seg-btn ${(settings.showStopReason ? "On" : "Off") === option ? "active" : ""}`}
+                onClick={() => update({ showStopReason: option === "On" })}
               >
-                {o}
+                {option}
               </button>
             ))}
           </div>
@@ -324,33 +478,131 @@ export default function SettingsPanel({
           </div>
         </div>
         <div className="settings-divider" />
+
         <div className="settings-row">
           <div className="settings-label-group">
             <span className="settings-label">Theme</span>
             <span className="settings-sublabel">
-              Switch between Dark and light themes.
+              Switch between dark and light themes.
             </span>
           </div>
           <div className="settings-seg-group">
-            {(["Dark", "Light"] as const).map((o) => (
+            {(["Dark", "Light"] as const).map((option) => (
               <button
-                key={o}
-                className={`settings-seg-btn ${(settings.theme === "light" ? "Light" : "Dark") === o ? "active" : ""}`}
+                key={option}
+                className={`settings-seg-btn ${(settings.theme === "light" ? "Light" : "Dark") === option ? "active" : ""}`}
                 onClick={() =>
-                  update({ theme: o.toLowerCase() as "dark" | "light" })
+                  update({ theme: option.toLowerCase() as "dark" | "light" })
                 }
               >
-                {o}
+                {option}
               </button>
             ))}
           </div>
         </div>
+
+        <div className="settings-row">
+          <div className="settings-label-group">
+            <span className="settings-label">Accent Color</span>
+            <span className="settings-sublabel">
+              Customize the primary accent used for active states.
+            </span>
+          </div>
+          <div className="settings-color-controls">
+            <label className="settings-color-picker">
+              <input
+                type="color"
+                value={settings.accentColor}
+                onChange={(event) => update({ accentColor: event.target.value })}
+              />
+            </label>
+            <span className="settings-value settings-value--mono">
+              {settings.accentColor.toUpperCase()}
+            </span>
+            <button
+              className="settings-btn-secondary"
+              onClick={() => update({ accentColor: DEFAULT_ACCENT_COLOR })}
+              disabled={settings.accentColor === DEFAULT_ACCENT_COLOR}
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+
         <div className="settings-divider" />
+
+        <div className="settings-row settings-row--stacked">
+          <div className="settings-label-group">
+            <span className="settings-label">Presets</span>
+            <span className="settings-sublabel">
+              Save and reuse named clicker configurations.
+            </span>
+          </div>
+          <div className="preset-compose">
+            <input
+              className="preset-name-input"
+              placeholder="Preset name"
+              value={newPresetName}
+              maxLength={PRESET_NAME_MAX_LENGTH}
+              onChange={(event) => setNewPresetName(event.target.value)}
+              disabled={running}
+            />
+            <button
+              className="settings-btn-primary"
+              onClick={handleSavePreset}
+              disabled={running || newPresetName.trim().length === 0}
+            >
+              Save New
+            </button>
+          </div>
+          {running && (
+            <span className="settings-note">
+              Preset actions are disabled while the clicker is running.
+            </span>
+          )}
+          {settings.presets.length > 0 ? (
+            <div className="preset-list">
+              {settings.presets.map((preset) => (
+                <PresetRow
+                  key={preset.id}
+                  preset={preset}
+                  isActive={settings.activePresetId === preset.id}
+                  isEditing={editingPresetId === preset.id}
+                  running={running}
+                  renameDraft={editingPresetId === preset.id ? renameDraft : preset.name}
+                  onRenameDraftChange={setRenameDraft}
+                  onStartRename={() => handleStartRename(preset)}
+                  onCancelRename={() => {
+                    setEditingPresetId(null);
+                    setRenameDraft("");
+                  }}
+                  onCommitRename={handleCommitRename}
+                  onApply={() => {
+                    onApplyPreset(preset.id);
+                  }}
+                  onUpdatePreset={() => {
+                    onUpdatePreset(preset.id);
+                  }}
+                  onDeletePreset={() => {
+                    onDeletePreset(preset.id);
+                  }}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="stats-empty">
+              No presets saved yet. Save one from your current clicker settings.
+            </div>
+          )}
+        </div>
+
+        <div className="settings-divider" />
+
         <div className="settings-row">
           <div className="settings-label-group">
             <span className="settings-label">Reset All Settings</span>
             <span className="settings-sublabel">
-              Will reset all input fields and settings to the Defaults.
+              Reset all saved settings and presets back to defaults.
             </span>
           </div>
           <button

--- a/src/components/panels/SettingsPanel.tsx
+++ b/src/components/panels/SettingsPanel.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-shell";
 import {
   DEFAULT_ACCENT_COLOR,
+  MAX_PRESETS,
   PRESET_NAME_MAX_LENGTH,
 } from "../../settingsSchema";
 
@@ -62,6 +63,7 @@ function PresetRow({
   preset,
   isActive,
   isEditing,
+  isConfirmingDelete,
   running,
   renameDraft,
   onRenameDraftChange,
@@ -70,11 +72,14 @@ function PresetRow({
   onCommitRename,
   onApply,
   onUpdatePreset,
-  onDeletePreset,
+  onRequestDelete,
+  onCancelDelete,
+  onConfirmDelete,
 }: {
   preset: PresetDefinition;
   isActive: boolean;
   isEditing: boolean;
+  isConfirmingDelete: boolean;
   running: boolean;
   renameDraft: string;
   onRenameDraftChange: (value: string) => void;
@@ -83,10 +88,15 @@ function PresetRow({
   onCommitRename: () => void;
   onApply: () => void;
   onUpdatePreset: () => void;
-  onDeletePreset: () => void;
+  onRequestDelete: () => void;
+  onCancelDelete: () => void;
+  onConfirmDelete: () => void;
 }) {
   return (
-    <div className={`preset-card ${isActive ? "preset-card--active" : ""}`}>
+    <div
+      className={`preset-card ${isActive ? "preset-card--active" : ""}`}
+      data-preset-id={preset.id}
+    >
       <div className="preset-card-head">
         <div className="preset-card-meta">
           {isEditing ? (
@@ -95,6 +105,17 @@ function PresetRow({
               value={renameDraft}
               maxLength={PRESET_NAME_MAX_LENGTH}
               onChange={(event) => onRenameDraftChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  onCommitRename();
+                }
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  onCancelRename();
+                }
+              }}
+              autoFocus
             />
           ) : (
             <span className="preset-name">{preset.name}</span>
@@ -117,6 +138,19 @@ function PresetRow({
                 Save
               </button>
               <button className="settings-btn-quiet" onClick={onCancelRename}>
+                Cancel
+              </button>
+            </>
+          ) : isConfirmingDelete ? (
+            <>
+              <button
+                className="settings-btn-danger settings-btn-danger--compact"
+                onClick={onConfirmDelete}
+                disabled={running}
+              >
+                Confirm?
+              </button>
+              <button className="settings-btn-quiet" onClick={onCancelDelete}>
                 Cancel
               </button>
             </>
@@ -145,7 +179,7 @@ function PresetRow({
               </button>
               <button
                 className="settings-btn-danger settings-btn-danger--compact"
-                onClick={onDeletePreset}
+                onClick={onRequestDelete}
                 disabled={running}
               >
                 Delete
@@ -178,6 +212,7 @@ export default function SettingsPanel({
   const [newPresetName, setNewPresetName] = useState("");
   const [editingPresetId, setEditingPresetId] = useState<PresetId | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<PresetId | null>(null);
 
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -190,6 +225,31 @@ export default function SettingsPanel({
       .catch(() => setAutostartEnabled(false));
   }, []);
 
+  useEffect(() => {
+    if (!confirmingDeleteId) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const presetCard = target.closest("[data-preset-id]");
+      if (presetCard?.getAttribute("data-preset-id") === confirmingDeleteId) {
+        return;
+      }
+
+      setConfirmingDeleteId(null);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [confirmingDeleteId]);
+
   const handleScroll = () => {
     const el = panelRef.current;
     if (!el) return;
@@ -199,10 +259,12 @@ export default function SettingsPanel({
   const handleSavePreset = () => {
     if (onSavePreset(newPresetName)) {
       setNewPresetName("");
+      setConfirmingDeleteId(null);
     }
   };
 
   const handleStartRename = (preset: PresetDefinition) => {
+    setConfirmingDeleteId(null);
     setEditingPresetId(preset.id);
     setRenameDraft(preset.name);
   };
@@ -218,6 +280,23 @@ export default function SettingsPanel({
     }
   };
 
+  const handleCancelRename = () => {
+    setEditingPresetId(null);
+    setRenameDraft("");
+  };
+
+  const handleRequestDelete = (presetId: PresetId) => {
+    setEditingPresetId(null);
+    setRenameDraft("");
+    setConfirmingDeleteId(presetId);
+  };
+
+  const handleConfirmDelete = (presetId: PresetId) => {
+    if (onDeletePreset(presetId)) {
+      setConfirmingDeleteId(null);
+    }
+  };
+
   const handleAlwaysOnTopChange = (nextValue: boolean) => {
     if (settings.alwaysOnTop === nextValue) {
       return;
@@ -227,6 +306,9 @@ export default function SettingsPanel({
   };
 
   const hasStats = stats !== null && stats.totalSessions > 0;
+  const presetLimitReached = settings.presets.length >= MAX_PRESETS;
+  const activeEditingPresetId = running ? null : editingPresetId;
+  const activeConfirmingDeleteId = running ? null : confirmingDeleteId;
 
   return (
     <div className="settings-wrapper">
@@ -545,16 +627,37 @@ export default function SettingsPanel({
               value={newPresetName}
               maxLength={PRESET_NAME_MAX_LENGTH}
               onChange={(event) => setNewPresetName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  if (!running && !presetLimitReached && newPresetName.trim()) {
+                    handleSavePreset();
+                  }
+                }
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  setNewPresetName("");
+                }
+              }}
               disabled={running}
             />
             <button
               className="settings-btn-primary"
               onClick={handleSavePreset}
-              disabled={running || newPresetName.trim().length === 0}
+              disabled={
+                running ||
+                presetLimitReached ||
+                newPresetName.trim().length === 0
+              }
             >
               Save New
             </button>
           </div>
+          {presetLimitReached && (
+            <span className="settings-note">
+              Preset limit reached. Delete one before saving another.
+            </span>
+          )}
           {running && (
             <span className="settings-note">
               Preset actions are disabled while the clicker is running.
@@ -567,25 +670,25 @@ export default function SettingsPanel({
                   key={preset.id}
                   preset={preset}
                   isActive={settings.activePresetId === preset.id}
-                  isEditing={editingPresetId === preset.id}
+                  isEditing={activeEditingPresetId === preset.id}
+                  isConfirmingDelete={activeConfirmingDeleteId === preset.id}
                   running={running}
-                  renameDraft={editingPresetId === preset.id ? renameDraft : preset.name}
+                  renameDraft={activeEditingPresetId === preset.id ? renameDraft : preset.name}
                   onRenameDraftChange={setRenameDraft}
                   onStartRename={() => handleStartRename(preset)}
-                  onCancelRename={() => {
-                    setEditingPresetId(null);
-                    setRenameDraft("");
-                  }}
+                  onCancelRename={handleCancelRename}
                   onCommitRename={handleCommitRename}
                   onApply={() => {
+                    setConfirmingDeleteId(null);
                     onApplyPreset(preset.id);
                   }}
                   onUpdatePreset={() => {
+                    setConfirmingDeleteId(null);
                     onUpdatePreset(preset.id);
                   }}
-                  onDeletePreset={() => {
-                    onDeletePreset(preset.id);
-                  }}
+                  onRequestDelete={() => handleRequestDelete(preset.id)}
+                  onCancelDelete={() => setConfirmingDeleteId(null)}
+                  onConfirmDelete={() => handleConfirmDelete(preset.id)}
                 />
               ))}
             </div>

--- a/src/components/panels/SimplePanel.tsx
+++ b/src/components/panels/SimplePanel.tsx
@@ -1,5 +1,11 @@
 import type { Settings } from "../../store";
 import HotkeyCaptureInput from "../HotkeyCaptureInput";
+import {
+  CLICK_INTERVAL_OPTIONS,
+  MODE_OPTIONS,
+  MOUSE_BUTTON_OPTIONS,
+  SETTINGS_LIMITS,
+} from "../../settingsSchema";
 import "./Modes.css";
 import "./SimplePanel.css";
 // I HATE MAKING UI, FUCK UI DESIGN IN CODE, WHY CANT I JUST PHOTOSHOP THIS SHIT
@@ -8,16 +14,6 @@ interface SimplePanelProps {
   settings: Settings;
   update: (patch: Partial<Settings>) => void;
 }
-
-const INTERVAL_OPTIONS = [
-  { value: "s", label: "Second" },
-  { value: "m", label: "Minute" },
-  { value: "h", label: "Hour" },
-  { value: "d", label: "Day" },
-] as const;
-
-const MODE_OPTIONS = ["Toggle", "Hold"] as const;
-const MOUSE_BUTTON_OPTIONS = ["Left", "Middle", "Right"] as const;
 
 export default function SimplePanel({ settings, update }: SimplePanelProps) {
   const normalizeRaw = (raw: string) => raw.replace(/^0+(?=\d)/, "");
@@ -95,12 +91,20 @@ export default function SimplePanel({ settings, update }: SimplePanelProps) {
                 e.target.value = normalized;
               }
               update({
-                clickSpeed: clamp(parseRawNumber(normalized), 1, 500),
+                clickSpeed: clamp(
+                  parseRawNumber(normalized),
+                  SETTINGS_LIMITS.clickSpeed.min,
+                  SETTINGS_LIMITS.clickSpeed.max,
+                ),
               });
             }}
             onWheel={(e) =>
-              handleWheelStep(e, settings.clickSpeed, 1, 500, (next) =>
-                update({ clickSpeed: next }),
+              handleWheelStep(
+                e,
+                settings.clickSpeed,
+                SETTINGS_LIMITS.clickSpeed.min,
+                SETTINGS_LIMITS.clickSpeed.max,
+                (next) => update({ clickSpeed: next }),
               )
             }
           />
@@ -114,7 +118,7 @@ export default function SimplePanel({ settings, update }: SimplePanelProps) {
               cycleWithClick(e, () =>
                 update({
                   clickInterval: cycleOption(
-                    INTERVAL_OPTIONS.map((o) => o.value),
+                    CLICK_INTERVAL_OPTIONS.map((o) => o.value),
                     settings.clickInterval,
                     1,
                   ),
@@ -125,7 +129,7 @@ export default function SimplePanel({ settings, update }: SimplePanelProps) {
               cycleWithClick(e, () =>
                 update({
                   clickInterval: cycleOption(
-                    INTERVAL_OPTIONS.map((o) => o.value),
+                    CLICK_INTERVAL_OPTIONS.map((o) => o.value),
                     settings.clickInterval,
                     -1,
                   ),
@@ -133,7 +137,7 @@ export default function SimplePanel({ settings, update }: SimplePanelProps) {
               )
             }
           >
-            {INTERVAL_OPTIONS.find((o) => o.value === settings.clickInterval)
+            {CLICK_INTERVAL_OPTIONS.find((o) => o.value === settings.clickInterval)
               ?.label ?? "Second"}
           </button>
           <svg
@@ -273,12 +277,20 @@ export default function SimplePanel({ settings, update }: SimplePanelProps) {
                 e.target.value = normalized;
               }
               update({
-                dutyCycle: clamp(parseRawNumber(normalized), 0, 100),
+                dutyCycle: clamp(
+                  parseRawNumber(normalized),
+                  SETTINGS_LIMITS.dutyCycle.min,
+                  SETTINGS_LIMITS.dutyCycle.max,
+                ),
               });
             }}
             onWheel={(e) =>
-              handleWheelStep(e, settings.dutyCycle, 0, 100, (next) =>
-                update({ dutyCycle: next }),
+              handleWheelStep(
+                e,
+                settings.dutyCycle,
+                SETTINGS_LIMITS.dutyCycle.min,
+                SETTINGS_LIMITS.dutyCycle.max,
+                (next) => update({ dutyCycle: next }),
               )
             }
           />
@@ -312,12 +324,20 @@ export default function SimplePanel({ settings, update }: SimplePanelProps) {
                 e.target.value = normalized;
               }
               update({
-                speedVariation: clamp(parseRawNumber(normalized), 0, 200),
+                speedVariation: clamp(
+                  parseRawNumber(normalized),
+                  SETTINGS_LIMITS.speedVariation.min,
+                  SETTINGS_LIMITS.speedVariation.max,
+                ),
               });
             }}
             onWheel={(e) =>
-              handleWheelStep(e, settings.speedVariation, 0, 200, (next) =>
-                update({ speedVariation: next }),
+              handleWheelStep(
+                e,
+                settings.speedVariation,
+                SETTINGS_LIMITS.speedVariation.min,
+                SETTINGS_LIMITS.speedVariation.max,
+                (next) => update({ speedVariation: next }),
               )
             }
           />

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,11 @@
   --text-dim:      hsla(180, 67%, 99%, 0.25);
 
   --accent-green:  hsla(129, 77%, 43%, 0.75);
+  --accent-green-strong: hsla(129, 77%, 43%, 0.92);
+  --accent-green-soft: hsla(129, 77%, 43%, 0.15);
+  --accent-green-ring: hsla(129, 77%, 43%, 0.35);
+  --accent-green-glow-1: hsla(129, 77%, 43%, 0.2);
+  --accent-green-glow-2: hsla(129, 77%, 43%, 0.12);
   --accent-yellow: hsla(41, 99%, 59%, 0.75);
   --accent-red:    hsla(4, 100%, 71%, 0.75);
 
@@ -61,6 +66,11 @@
   --text-dim:      hsla(0, 0%, 0%, 0.65);
 
   --accent-green:  hsla(129, 77%, 30%, 0.9);
+  --accent-green-strong: hsla(129, 77%, 30%, 1);
+  --accent-green-soft: hsla(129, 77%, 30%, 0.2);
+  --accent-green-ring: hsla(129, 77%, 30%, 0.4);
+  --accent-green-glow-1: hsla(129, 77%, 30%, 0.16);
+  --accent-green-glow-2: hsla(129, 77%, 30%, 0.08);
   --accent-yellow: hsla(41, 99%, 35%, 0.9);
   --accent-red:    hsla(4, 100%, 45%, 0.9);
 
@@ -88,7 +98,7 @@
 
 body {
   color: var(--text-primary);
-  font-family: 'DMSans', sans-serif;
+  font-family: var(--font-family-base);
   font-size: 1rem;
   overflow: hidden;
   user-select: none;
@@ -111,7 +121,7 @@ body {
 
 .panel-area {
   flex: 1;
-  padding: 1.25rem 1.25rem 1.25rem 1.25rem;
+  padding: 1.25rem;
   display: flex;
   flex-direction: column;
   overflow: auto;

--- a/src/settingsSchema.ts
+++ b/src/settingsSchema.ts
@@ -11,7 +11,6 @@ export interface PresetSnapshot {
   clickSpeed: number;
   clickInterval: ClickInterval;
   mouseButton: MouseButton;
-  hotkey: string;
   mode: ClickMode;
   dutyCycleEnabled: boolean;
   dutyCycle: number;
@@ -49,6 +48,7 @@ export interface PresetDefinition {
 
 export interface Settings extends PresetSnapshot {
   version: string;
+  hotkey: string;
   disableScreenshots: boolean;
   advancedSettingsEnabled: boolean;
   explanationMode: ExplanationMode;
@@ -65,6 +65,7 @@ export interface Settings extends PresetSnapshot {
 }
 
 export const DEFAULT_ACCENT_COLOR = "#22c55e";
+export const MAX_PRESETS = 20;
 export const PRESET_NAME_MAX_LENGTH = 40;
 
 export const CLICK_INTERVAL_OPTIONS = [
@@ -94,7 +95,6 @@ export const PRESET_SNAPSHOT_KEYS = [
   "clickSpeed",
   "clickInterval",
   "mouseButton",
-  "hotkey",
   "mode",
   "dutyCycleEnabled",
   "dutyCycle",
@@ -238,7 +238,6 @@ export function buildPresetSnapshot(settings: Settings): PresetSnapshot {
     clickSpeed: settings.clickSpeed,
     clickInterval: settings.clickInterval,
     mouseButton: settings.mouseButton,
-    hotkey: settings.hotkey,
     mode: settings.mode,
     dutyCycleEnabled: settings.dutyCycleEnabled,
     dutyCycle: settings.dutyCycle,
@@ -303,7 +302,6 @@ function sanitizePresetSnapshot(
 
   return {
     ...defaults,
-    ...saved,
     clickSpeed: clampNumber(
       saved.clickSpeed,
       defaults.clickSpeed,
@@ -320,7 +318,6 @@ function sanitizePresetSnapshot(
       saved.mouseButton === "Middle" || saved.mouseButton === "Right"
         ? saved.mouseButton
         : defaults.mouseButton,
-    hotkey: typeof saved.hotkey === "string" ? saved.hotkey : defaults.hotkey,
     mode: saved.mode === "Hold" ? "Hold" : defaults.mode,
     dutyCycleEnabled: sanitizeBoolean(
       saved.dutyCycleEnabled,
@@ -456,6 +453,7 @@ function sanitizePresets(input: unknown, defaults: Settings): PresetDefinition[]
   const defaultSnapshot = buildPresetSnapshot(defaults);
 
   return input
+    .slice(0, MAX_PRESETS)
     .map((preset, index) => {
       if (!preset || typeof preset !== "object") {
         return null;

--- a/src/settingsSchema.ts
+++ b/src/settingsSchema.ts
@@ -1,0 +1,649 @@
+export type ClickInterval = "s" | "m" | "h" | "d";
+export type MouseButton = "Left" | "Middle" | "Right";
+export type ClickMode = "Toggle" | "Hold";
+export type TimeLimitUnit = "s" | "m" | "h";
+export type SavedPanel = "simple" | "advanced";
+export type ExplanationMode = "off" | "text";
+export type Theme = "dark" | "light";
+export type PresetId = string;
+
+export interface PresetSnapshot {
+  clickSpeed: number;
+  clickInterval: ClickInterval;
+  mouseButton: MouseButton;
+  hotkey: string;
+  mode: ClickMode;
+  dutyCycleEnabled: boolean;
+  dutyCycle: number;
+  speedVariationEnabled: boolean;
+  speedVariation: number;
+  doubleClickEnabled: boolean;
+  doubleClickDelay: number;
+  clickLimitEnabled: boolean;
+  clickLimit: number;
+  timeLimitEnabled: boolean;
+  timeLimit: number;
+  timeLimitUnit: TimeLimitUnit;
+  cornerStopEnabled: boolean;
+  cornerStopTL: number;
+  cornerStopTR: number;
+  cornerStopBL: number;
+  cornerStopBR: number;
+  edgeStopEnabled: boolean;
+  edgeStopTop: number;
+  edgeStopBottom: number;
+  edgeStopLeft: number;
+  edgeStopRight: number;
+  positionEnabled: boolean;
+  positionX: number;
+  positionY: number;
+}
+
+export interface PresetDefinition {
+  id: PresetId;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  settings: PresetSnapshot;
+}
+
+export interface Settings extends PresetSnapshot {
+  version: string;
+  disableScreenshots: boolean;
+  advancedSettingsEnabled: boolean;
+  explanationMode: ExplanationMode;
+  lastPanel: SavedPanel;
+  showStopReason: boolean;
+  showStopOverlay: boolean;
+  strictHotkeyModifiers: boolean;
+  minimizeToTray: boolean;
+  theme: Theme;
+  alwaysOnTop: boolean;
+  accentColor: string;
+  presets: PresetDefinition[];
+  activePresetId: PresetId | null;
+}
+
+export const DEFAULT_ACCENT_COLOR = "#22c55e";
+export const PRESET_NAME_MAX_LENGTH = 40;
+
+export const CLICK_INTERVAL_OPTIONS = [
+  { value: "s", label: "Second" },
+  { value: "m", label: "Minute" },
+  { value: "h", label: "Hour" },
+  { value: "d", label: "Day" },
+] as const satisfies ReadonlyArray<{ value: ClickInterval; label: string }>;
+
+export const MODE_OPTIONS = ["Toggle", "Hold"] as const satisfies ReadonlyArray<ClickMode>;
+export const MOUSE_BUTTON_OPTIONS = ["Left", "Middle", "Right"] as const satisfies ReadonlyArray<MouseButton>;
+export const TIME_LIMIT_UNIT_OPTIONS = ["s", "m", "h"] as const satisfies ReadonlyArray<TimeLimitUnit>;
+export const THEME_OPTIONS = ["dark", "light"] as const satisfies ReadonlyArray<Theme>;
+
+export const SETTINGS_LIMITS = {
+  clickSpeed: { min: 1, max: 500 },
+  dutyCycle: { min: 0, max: 100 },
+  speedVariation: { min: 0, max: 200 },
+  doubleClickDelay: { min: 20, max: 9999 },
+  clickLimit: { min: 1, max: 10_000_000 },
+  timeLimit: { min: 1 },
+  stopBoundary: { min: 0, max: 999 },
+  position: { min: 0 },
+} as const;
+
+export const PRESET_SNAPSHOT_KEYS = [
+  "clickSpeed",
+  "clickInterval",
+  "mouseButton",
+  "hotkey",
+  "mode",
+  "dutyCycleEnabled",
+  "dutyCycle",
+  "speedVariationEnabled",
+  "speedVariation",
+  "doubleClickEnabled",
+  "doubleClickDelay",
+  "clickLimitEnabled",
+  "clickLimit",
+  "timeLimitEnabled",
+  "timeLimit",
+  "timeLimitUnit",
+  "cornerStopEnabled",
+  "cornerStopTL",
+  "cornerStopTR",
+  "cornerStopBL",
+  "cornerStopBR",
+  "edgeStopEnabled",
+  "edgeStopTop",
+  "edgeStopBottom",
+  "edgeStopLeft",
+  "edgeStopRight",
+  "positionEnabled",
+  "positionX",
+  "positionY",
+] as const satisfies ReadonlyArray<keyof PresetSnapshot>;
+
+export function clampNumber(
+  value: unknown,
+  fallback: number,
+  min?: number,
+  max?: number,
+) {
+  const parsed =
+    typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  const minClamped = min === undefined ? parsed : Math.max(min, parsed);
+  return max === undefined ? minClamped : Math.min(max, minClamped);
+}
+
+export function sanitizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function sanitizeSavedPanel(value: unknown): SavedPanel {
+  return value === "advanced" ? value : "simple";
+}
+
+function sanitizeExplanationMode(
+  input: Partial<Settings> | null | undefined,
+): ExplanationMode {
+  const saved = (input ?? {}) as Partial<Settings> & {
+    functionExplanationsEnabled?: boolean;
+    toolTipsEnabled?: boolean;
+    explanationMode?: unknown;
+  };
+
+  if (saved.explanationMode === "off" || saved.explanationMode === "text") {
+    return saved.explanationMode;
+  }
+
+  if (saved.toolTipsEnabled) return "text";
+  if (saved.functionExplanationsEnabled === false) return "off";
+  return "text";
+}
+
+function sanitizeTheme(value: unknown): Theme {
+  return value === "light" ? "light" : "dark";
+}
+
+export function sanitizeHexColor(value: unknown, fallback: string): string {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return /^#[0-9a-f]{6}$/.test(normalized) ? normalized : fallback;
+}
+
+export function sanitizePresetName(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim().slice(0, PRESET_NAME_MAX_LENGTH);
+}
+
+function createFallbackPresetId(index: number) {
+  return `preset-${index + 1}`;
+}
+
+export function createDefaultSettings(version: string): Settings {
+  return {
+    version,
+    clickSpeed: 25,
+    clickInterval: "s",
+    mouseButton: "Left",
+    hotkey: "ctrl+y",
+    mode: "Toggle",
+    dutyCycleEnabled: true,
+    dutyCycle: 45,
+    speedVariationEnabled: true,
+    speedVariation: 35,
+    doubleClickEnabled: false,
+    doubleClickDelay: 40,
+    clickLimitEnabled: false,
+    clickLimit: 1000,
+    timeLimitEnabled: false,
+    timeLimit: 60,
+    timeLimitUnit: "s",
+    cornerStopEnabled: true,
+    cornerStopTL: 50,
+    cornerStopTR: 50,
+    cornerStopBL: 50,
+    cornerStopBR: 50,
+    edgeStopEnabled: true,
+    edgeStopTop: 40,
+    edgeStopBottom: 40,
+    edgeStopLeft: 40,
+    edgeStopRight: 40,
+    positionEnabled: false,
+    positionX: 0,
+    positionY: 0,
+    disableScreenshots: false,
+    advancedSettingsEnabled: true,
+    explanationMode: "text",
+    lastPanel: "simple",
+    showStopReason: true,
+    showStopOverlay: true,
+    strictHotkeyModifiers: false,
+    minimizeToTray: false,
+    theme: "dark",
+    alwaysOnTop: false,
+    accentColor: DEFAULT_ACCENT_COLOR,
+    presets: [],
+    activePresetId: null,
+  };
+}
+
+export function buildPresetSnapshot(settings: Settings): PresetSnapshot {
+  return {
+    clickSpeed: settings.clickSpeed,
+    clickInterval: settings.clickInterval,
+    mouseButton: settings.mouseButton,
+    hotkey: settings.hotkey,
+    mode: settings.mode,
+    dutyCycleEnabled: settings.dutyCycleEnabled,
+    dutyCycle: settings.dutyCycle,
+    speedVariationEnabled: settings.speedVariationEnabled,
+    speedVariation: settings.speedVariation,
+    doubleClickEnabled: settings.doubleClickEnabled,
+    doubleClickDelay: settings.doubleClickDelay,
+    clickLimitEnabled: settings.clickLimitEnabled,
+    clickLimit: settings.clickLimit,
+    timeLimitEnabled: settings.timeLimitEnabled,
+    timeLimit: settings.timeLimit,
+    timeLimitUnit: settings.timeLimitUnit,
+    cornerStopEnabled: settings.cornerStopEnabled,
+    cornerStopTL: settings.cornerStopTL,
+    cornerStopTR: settings.cornerStopTR,
+    cornerStopBL: settings.cornerStopBL,
+    cornerStopBR: settings.cornerStopBR,
+    edgeStopEnabled: settings.edgeStopEnabled,
+    edgeStopTop: settings.edgeStopTop,
+    edgeStopBottom: settings.edgeStopBottom,
+    edgeStopLeft: settings.edgeStopLeft,
+    edgeStopRight: settings.edgeStopRight,
+    positionEnabled: settings.positionEnabled,
+    positionX: settings.positionX,
+    positionY: settings.positionY,
+  };
+}
+
+export function applyPresetSnapshot(
+  base: Settings,
+  snapshot: PresetSnapshot,
+): Settings {
+  return {
+    ...base,
+    ...snapshot,
+  };
+}
+
+export function createPresetDefinition(
+  name: string,
+  settings: Settings,
+): PresetDefinition {
+  const now = new Date().toISOString();
+  const id =
+    globalThis.crypto?.randomUUID?.() ??
+    `preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  return {
+    id,
+    name: sanitizePresetName(name),
+    createdAt: now,
+    updatedAt: now,
+    settings: buildPresetSnapshot(settings),
+  };
+}
+
+function sanitizePresetSnapshot(
+  input: unknown,
+  defaults: PresetSnapshot,
+): PresetSnapshot {
+  const saved = (input ?? {}) as Partial<PresetSnapshot>;
+
+  return {
+    ...defaults,
+    ...saved,
+    clickSpeed: clampNumber(
+      saved.clickSpeed,
+      defaults.clickSpeed,
+      SETTINGS_LIMITS.clickSpeed.min,
+      SETTINGS_LIMITS.clickSpeed.max,
+    ),
+    clickInterval:
+      saved.clickInterval === "m" ||
+      saved.clickInterval === "h" ||
+      saved.clickInterval === "d"
+        ? saved.clickInterval
+        : defaults.clickInterval,
+    mouseButton:
+      saved.mouseButton === "Middle" || saved.mouseButton === "Right"
+        ? saved.mouseButton
+        : defaults.mouseButton,
+    hotkey: typeof saved.hotkey === "string" ? saved.hotkey : defaults.hotkey,
+    mode: saved.mode === "Hold" ? "Hold" : defaults.mode,
+    dutyCycleEnabled: sanitizeBoolean(
+      saved.dutyCycleEnabled,
+      defaults.dutyCycleEnabled,
+    ),
+    dutyCycle: clampNumber(
+      saved.dutyCycle,
+      defaults.dutyCycle,
+      SETTINGS_LIMITS.dutyCycle.min,
+      SETTINGS_LIMITS.dutyCycle.max,
+    ),
+    speedVariationEnabled: sanitizeBoolean(
+      saved.speedVariationEnabled,
+      defaults.speedVariationEnabled,
+    ),
+    speedVariation: clampNumber(
+      saved.speedVariation,
+      defaults.speedVariation,
+      SETTINGS_LIMITS.speedVariation.min,
+      SETTINGS_LIMITS.speedVariation.max,
+    ),
+    doubleClickEnabled: sanitizeBoolean(
+      saved.doubleClickEnabled,
+      defaults.doubleClickEnabled,
+    ),
+    doubleClickDelay: clampNumber(
+      saved.doubleClickDelay,
+      defaults.doubleClickDelay,
+      SETTINGS_LIMITS.doubleClickDelay.min,
+      SETTINGS_LIMITS.doubleClickDelay.max,
+    ),
+    clickLimitEnabled: sanitizeBoolean(
+      saved.clickLimitEnabled,
+      defaults.clickLimitEnabled,
+    ),
+    clickLimit: clampNumber(
+      saved.clickLimit,
+      defaults.clickLimit,
+      SETTINGS_LIMITS.clickLimit.min,
+      SETTINGS_LIMITS.clickLimit.max,
+    ),
+    timeLimitEnabled: sanitizeBoolean(
+      saved.timeLimitEnabled,
+      defaults.timeLimitEnabled,
+    ),
+    timeLimit: clampNumber(
+      saved.timeLimit,
+      defaults.timeLimit,
+      SETTINGS_LIMITS.timeLimit.min,
+    ),
+    timeLimitUnit:
+      saved.timeLimitUnit === "m" || saved.timeLimitUnit === "h"
+        ? saved.timeLimitUnit
+        : defaults.timeLimitUnit,
+    cornerStopEnabled: sanitizeBoolean(
+      saved.cornerStopEnabled,
+      defaults.cornerStopEnabled,
+    ),
+    cornerStopTL: clampNumber(
+      saved.cornerStopTL,
+      defaults.cornerStopTL,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    cornerStopTR: clampNumber(
+      saved.cornerStopTR,
+      defaults.cornerStopTR,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    cornerStopBL: clampNumber(
+      saved.cornerStopBL,
+      defaults.cornerStopBL,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    cornerStopBR: clampNumber(
+      saved.cornerStopBR,
+      defaults.cornerStopBR,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    edgeStopEnabled: sanitizeBoolean(
+      saved.edgeStopEnabled,
+      defaults.edgeStopEnabled,
+    ),
+    edgeStopTop: clampNumber(
+      saved.edgeStopTop,
+      defaults.edgeStopTop,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    edgeStopBottom: clampNumber(
+      saved.edgeStopBottom,
+      defaults.edgeStopBottom,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    edgeStopLeft: clampNumber(
+      saved.edgeStopLeft,
+      defaults.edgeStopLeft,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    edgeStopRight: clampNumber(
+      saved.edgeStopRight,
+      defaults.edgeStopRight,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    positionEnabled: sanitizeBoolean(
+      saved.positionEnabled,
+      defaults.positionEnabled,
+    ),
+    positionX: clampNumber(
+      saved.positionX,
+      defaults.positionX,
+      SETTINGS_LIMITS.position.min,
+    ),
+    positionY: clampNumber(
+      saved.positionY,
+      defaults.positionY,
+      SETTINGS_LIMITS.position.min,
+    ),
+  };
+}
+
+function sanitizePresets(input: unknown, defaults: Settings): PresetDefinition[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  const defaultSnapshot = buildPresetSnapshot(defaults);
+
+  return input
+    .map((preset, index) => {
+      if (!preset || typeof preset !== "object") {
+        return null;
+      }
+
+      const saved = preset as Partial<PresetDefinition>;
+      const name = sanitizePresetName(saved.name);
+      if (!name) {
+        return null;
+      }
+
+      const now = new Date().toISOString();
+
+      return {
+        id:
+          typeof saved.id === "string" && saved.id.trim()
+            ? saved.id.trim()
+            : createFallbackPresetId(index),
+        name,
+        createdAt:
+          typeof saved.createdAt === "string" && saved.createdAt
+            ? saved.createdAt
+            : now,
+        updatedAt:
+          typeof saved.updatedAt === "string" && saved.updatedAt
+            ? saved.updatedAt
+            : now,
+        settings: sanitizePresetSnapshot(saved.settings, defaultSnapshot),
+      } satisfies PresetDefinition;
+    })
+    .filter((preset): preset is PresetDefinition => preset !== null);
+}
+
+export function sanitizeSettings(
+  input: Partial<Settings> | null | undefined,
+  version: string,
+): Settings {
+  const defaults = createDefaultSettings(version);
+  const saved = (input ?? {}) as Partial<Settings> & {
+    speedVariationMax?: unknown;
+    telemetryEnabled?: unknown;
+  };
+  const legacySpeedVariation = clampNumber(
+    saved.speedVariationMax,
+    defaults.speedVariation,
+    SETTINGS_LIMITS.speedVariation.min,
+    SETTINGS_LIMITS.speedVariation.max,
+  );
+  const presets = sanitizePresets(saved.presets, defaults);
+
+  return {
+    ...defaults,
+    ...saved,
+    version,
+    clickSpeed: clampNumber(
+      saved.clickSpeed,
+      defaults.clickSpeed,
+      SETTINGS_LIMITS.clickSpeed.min,
+      SETTINGS_LIMITS.clickSpeed.max,
+    ),
+    dutyCycleEnabled: sanitizeBoolean(
+      saved.dutyCycleEnabled,
+      defaults.dutyCycleEnabled,
+    ),
+    dutyCycle: clampNumber(
+      saved.dutyCycle,
+      defaults.dutyCycle,
+      SETTINGS_LIMITS.dutyCycle.min,
+      SETTINGS_LIMITS.dutyCycle.max,
+    ),
+    speedVariationEnabled: sanitizeBoolean(
+      saved.speedVariationEnabled,
+      defaults.speedVariationEnabled,
+    ),
+    speedVariation: clampNumber(
+      saved.speedVariation,
+      legacySpeedVariation,
+      SETTINGS_LIMITS.speedVariation.min,
+      SETTINGS_LIMITS.speedVariation.max,
+    ),
+    doubleClickEnabled: sanitizeBoolean(
+      saved.doubleClickEnabled,
+      defaults.doubleClickEnabled,
+    ),
+    doubleClickDelay: clampNumber(
+      saved.doubleClickDelay,
+      defaults.doubleClickDelay,
+      SETTINGS_LIMITS.doubleClickDelay.min,
+      SETTINGS_LIMITS.doubleClickDelay.max,
+    ),
+    clickLimitEnabled: sanitizeBoolean(
+      saved.clickLimitEnabled,
+      defaults.clickLimitEnabled,
+    ),
+    clickLimit: clampNumber(
+      saved.clickLimit,
+      defaults.clickLimit,
+      SETTINGS_LIMITS.clickLimit.min,
+      SETTINGS_LIMITS.clickLimit.max,
+    ),
+    timeLimitEnabled: sanitizeBoolean(
+      saved.timeLimitEnabled,
+      defaults.timeLimitEnabled,
+    ),
+    timeLimit: clampNumber(
+      saved.timeLimit,
+      defaults.timeLimit,
+      SETTINGS_LIMITS.timeLimit.min,
+    ),
+    cornerStopEnabled: sanitizeBoolean(
+      saved.cornerStopEnabled,
+      defaults.cornerStopEnabled,
+    ),
+    cornerStopTL: clampNumber(
+      saved.cornerStopTL,
+      defaults.cornerStopTL,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    cornerStopTR: clampNumber(
+      saved.cornerStopTR,
+      defaults.cornerStopTR,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    cornerStopBL: clampNumber(
+      saved.cornerStopBL,
+      defaults.cornerStopBL,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    cornerStopBR: clampNumber(
+      saved.cornerStopBR,
+      defaults.cornerStopBR,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    edgeStopEnabled: sanitizeBoolean(
+      saved.edgeStopEnabled,
+      defaults.edgeStopEnabled,
+    ),
+    edgeStopTop: clampNumber(
+      saved.edgeStopTop,
+      defaults.edgeStopTop,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    edgeStopBottom: clampNumber(
+      saved.edgeStopBottom,
+      defaults.edgeStopBottom,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    edgeStopLeft: clampNumber(
+      saved.edgeStopLeft,
+      defaults.edgeStopLeft,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    edgeStopRight: clampNumber(
+      saved.edgeStopRight,
+      defaults.edgeStopRight,
+      SETTINGS_LIMITS.stopBoundary.min,
+      SETTINGS_LIMITS.stopBoundary.max,
+    ),
+    positionX: clampNumber(
+      saved.positionX,
+      defaults.positionX,
+      SETTINGS_LIMITS.position.min,
+    ),
+    positionY: clampNumber(
+      saved.positionY,
+      defaults.positionY,
+      SETTINGS_LIMITS.position.min,
+    ),
+    disableScreenshots: false,
+    explanationMode: sanitizeExplanationMode(saved),
+    lastPanel: sanitizeSavedPanel(saved.lastPanel),
+    theme: sanitizeTheme(saved.theme),
+    strictHotkeyModifiers: sanitizeBoolean(saved.strictHotkeyModifiers, defaults.strictHotkeyModifiers),
+    minimizeToTray: sanitizeBoolean(saved.minimizeToTray, defaults.minimizeToTray),
+    alwaysOnTop: sanitizeBoolean(saved.alwaysOnTop, defaults.alwaysOnTop),
+    accentColor: sanitizeHexColor(saved.accentColor, defaults.accentColor),
+    presets,
+    activePresetId:
+      typeof saved.activePresetId === "string" &&
+      presets.some((preset) => preset.id === saved.activePresetId)
+        ? saved.activePresetId
+        : null,
+  };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,55 +1,28 @@
 import { getVersion } from "@tauri-apps/api/app";
 import { LazyStore } from "@tauri-apps/plugin-store";
+import {
+  createDefaultSettings,
+  sanitizeSettings,
+  type Settings,
+} from "./settingsSchema";
 
 const store = new LazyStore("settings.json");
 
 export const APP_VERSION = await getVersion();
 
-export type SavedPanel = "simple" | "advanced";
-export type ExplanationMode = "off" | "text";
-export type Theme = "dark" | "light";
-
-export interface Settings {
-  version: string;
-  clickSpeed: number;
-  clickInterval: "s" | "m" | "h" | "d";
-  mouseButton: "Left" | "Middle" | "Right";
-  hotkey: string;
-  mode: "Toggle" | "Hold";
-  dutyCycleEnabled: boolean;
-  dutyCycle: number;
-  speedVariationEnabled: boolean;
-  speedVariation: number;
-  doubleClickEnabled: boolean;
-  doubleClickDelay: number;
-  clickLimitEnabled: boolean;
-  clickLimit: number;
-  timeLimitEnabled: boolean;
-  timeLimit: number;
-  timeLimitUnit: "s" | "m" | "h";
-  cornerStopEnabled: boolean;
-  cornerStopTL: number;
-  cornerStopTR: number;
-  cornerStopBL: number;
-  cornerStopBR: number;
-  edgeStopEnabled: boolean;
-  edgeStopTop: number;
-  edgeStopBottom: number;
-  edgeStopLeft: number;
-  edgeStopRight: number;
-  positionEnabled: boolean;
-  positionX: number;
-  positionY: number;
-  disableScreenshots: boolean;
-  advancedSettingsEnabled: boolean;
-  explanationMode: ExplanationMode;
-  lastPanel: SavedPanel;
-  showStopReason: boolean;
-  showStopOverlay: boolean;
-  strictHotkeyModifiers: boolean;
-  theme: Theme;
-  minimizeToTray: boolean;
-}
+export type {
+  ClickInterval,
+  ClickMode,
+  ExplanationMode,
+  MouseButton,
+  PresetDefinition,
+  PresetId,
+  PresetSnapshot,
+  SavedPanel,
+  Settings,
+  Theme,
+  TimeLimitUnit,
+} from "./settingsSchema";
 
 export interface ClickerStatus {
   running: boolean;
@@ -64,190 +37,15 @@ export interface AppInfo {
   screenshotProtectionSupported: boolean;
 }
 
-export const DEFAULT_SETTINGS: Settings = {
-  version: APP_VERSION,
-  clickSpeed: 25,
-  clickInterval: "s",
-  mouseButton: "Left",
-  hotkey: "ctrl+y",
-  mode: "Toggle",
-  dutyCycleEnabled: true,
-  dutyCycle: 45,
-  speedVariationEnabled: true,
-  speedVariation: 35,
-  doubleClickEnabled: false,
-  doubleClickDelay: 40,
-  clickLimitEnabled: false,
-  clickLimit: 1000,
-  timeLimitEnabled: false,
-  timeLimit: 60,
-  timeLimitUnit: "s",
-  cornerStopEnabled: true,
-  cornerStopTL: 50,
-  cornerStopTR: 50,
-  cornerStopBL: 50,
-  cornerStopBR: 50,
-  edgeStopEnabled: true,
-  edgeStopTop: 40,
-  edgeStopBottom: 40,
-  edgeStopLeft: 40,
-  edgeStopRight: 40,
-  positionEnabled: false,
-  positionX: 0,
-  positionY: 0,
-  disableScreenshots: false,
-  advancedSettingsEnabled: true,
-  explanationMode: "text",
-  lastPanel: "simple",
-  showStopReason: true,
-  showStopOverlay: true,
-  strictHotkeyModifiers: false,
-  theme: "dark",
-  minimizeToTray: false,
-};
-
-function sanitizeSavedPanel(value: unknown): SavedPanel {
-  return value === "advanced" ? value : "simple";
-}
-
-function sanitizeExplanationMode(
-  input: Partial<Settings> | null | undefined,
-): ExplanationMode {
-  const saved = (input ?? {}) as Partial<Settings> & {
-    functionExplanationsEnabled?: boolean;
-    toolTipsEnabled?: boolean;
-    explanationMode?: unknown;
-  };
-
-  if (saved.explanationMode === "off" || saved.explanationMode === "text") {
-    return saved.explanationMode;
-  }
-
-  if (saved.toolTipsEnabled) return "text";
-  if (saved.functionExplanationsEnabled === false) return "off";
-  return "text";
-}
-
-function sanitizeBoolean(value: unknown, fallback: boolean): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
-function clampNumber(
-  value: unknown,
-  fallback: number,
-  min?: number,
-  max?: number,
-) {
-  const parsed =
-    typeof value === "number" && Number.isFinite(value) ? value : fallback;
-  const minClamped = min === undefined ? parsed : Math.max(min, parsed);
-  return max === undefined ? minClamped : Math.min(max, minClamped);
-}
-
-function sanitizeSettings(input?: Partial<Settings> | null): Settings {
-  const saved = (input ?? {}) as Partial<Settings> & {
-    speedVariationMax?: unknown;
-    telemetryEnabled?: unknown;
-  };
-  const legacySpeedVariation = clampNumber(
-    saved.speedVariationMax,
-    DEFAULT_SETTINGS.speedVariation,
-    0,
-    200,
-  );
-
-  return {
-    ...DEFAULT_SETTINGS,
-    ...saved,
-    version: APP_VERSION,
-    clickSpeed: clampNumber(
-      saved.clickSpeed,
-      DEFAULT_SETTINGS.clickSpeed,
-      1,
-      500,
-    ),
-    dutyCycleEnabled: sanitizeBoolean(
-      saved.dutyCycleEnabled,
-      DEFAULT_SETTINGS.dutyCycleEnabled,
-    ),
-    speedVariationEnabled: sanitizeBoolean(
-      saved.speedVariationEnabled,
-      DEFAULT_SETTINGS.speedVariationEnabled,
-    ),
-    speedVariation: clampNumber(saved.speedVariation, legacySpeedVariation, 0, 200),
-    doubleClickDelay: clampNumber(
-      saved.doubleClickDelay,
-      DEFAULT_SETTINGS.doubleClickDelay,
-      20,
-      9999,
-    ),
-    clickLimit: clampNumber(saved.clickLimit, DEFAULT_SETTINGS.clickLimit, 1),
-    timeLimit: clampNumber(saved.timeLimit, DEFAULT_SETTINGS.timeLimit, 1),
-    cornerStopTL: clampNumber(
-      saved.cornerStopTL,
-      DEFAULT_SETTINGS.cornerStopTL,
-      0,
-      999,
-    ),
-    cornerStopTR: clampNumber(
-      saved.cornerStopTR,
-      DEFAULT_SETTINGS.cornerStopTR,
-      0,
-      999,
-    ),
-    cornerStopBL: clampNumber(
-      saved.cornerStopBL,
-      DEFAULT_SETTINGS.cornerStopBL,
-      0,
-      999,
-    ),
-    cornerStopBR: clampNumber(
-      saved.cornerStopBR,
-      DEFAULT_SETTINGS.cornerStopBR,
-      0,
-      999,
-    ),
-    edgeStopTop: clampNumber(
-      saved.edgeStopTop,
-      DEFAULT_SETTINGS.edgeStopTop,
-      0,
-      999,
-    ),
-    edgeStopBottom: clampNumber(
-      saved.edgeStopBottom,
-      DEFAULT_SETTINGS.edgeStopBottom,
-      0,
-      999,
-    ),
-    edgeStopLeft: clampNumber(
-      saved.edgeStopLeft,
-      DEFAULT_SETTINGS.edgeStopLeft,
-      0,
-      999,
-    ),
-    edgeStopRight: clampNumber(
-      saved.edgeStopRight,
-      DEFAULT_SETTINGS.edgeStopRight,
-      0,
-      999,
-    ),
-    positionX: clampNumber(saved.positionX, DEFAULT_SETTINGS.positionX, 0),
-    positionY: clampNumber(saved.positionY, DEFAULT_SETTINGS.positionY, 0),
-    disableScreenshots: false,
-    explanationMode: sanitizeExplanationMode(saved),
-    lastPanel: sanitizeSavedPanel(saved.lastPanel),
-    theme: saved.theme === "light" ? "light" : "dark",
-    minimizeToTray: sanitizeBoolean(saved.minimizeToTray, false),
-  };
-}
+export const DEFAULT_SETTINGS: Settings = createDefaultSettings(APP_VERSION);
 
 export async function loadSettings(): Promise<Settings> {
   const saved = await store.get<Partial<Settings>>("settings");
-  return sanitizeSettings(saved);
+  return sanitizeSettings(saved, APP_VERSION);
 }
 
 export async function saveSettings(settings: Settings): Promise<void> {
-  await store.set("settings", sanitizeSettings(settings));
+  await store.set("settings", sanitizeSettings(settings, APP_VERSION));
   await store.save();
 }
 


### PR DESCRIPTION
## Summary

Adds a bounded improvement pass on top of current upstream `main` without overlapping the active upstream PR queue.

### What’s included

- named presets for operational clicker settings
- persistent `Always on Top` preference with title-bar + settings controls
- accent color customization layered on top of the existing dark/light themes
- shared frontend settings schema/helpers to remove duplicated bounds/options logic
- cleanup of existing mojibake in changelog/runtime text

### What’s intentionally excluded

This PR does not duplicate work already proposed upstream:
- tray/minimize support
- package/tauri script rewiring
- translation/i18n
- CSS token/Tailwind cleanup
- hotkey robustness changes
- WebView2 bundling
- portable zip bundles
- CI workflow
- keyboard auto-press

### Validation

- `npm run lint`
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`

## Assumptions And Defaults

- Use upstream PR history as the overlap source of truth because the fork has no PR history.
- Start from fresh `upstream/main`, not from current PR `#64`.
- Keep this to one medium-sized PR.
- Presets are for clicker behavior only, not global UI preferences.
- `alwaysOnTop` and `accentColor` are global preferences, not preset-bound.
- Schema version moves to `7` to avoid collision with open PR `#75`.
- No package/CI/portable/WebView2 changes in this PR because those areas already have active upstream PRs.
