### PR TITLE
build: add optional Windows signing plumbing and release trust docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,10 @@ Config and stats are stored in `%appdata%/BlurAutoClicker`.
 *Info: If you are on version 2.1.2 or below, delete the old executable (the installer will not delete it for you).
 The old Config and Stats files will unfortunately not be compatible with the new versions (3.0.0 and above), so they will be deleted upon launching the application.*
 
+### Windows trust / signing
+
+Unsigned GitHub-downloaded Windows installers can still show a SmartScreen warning. Tauri updater signing is separate from Windows Authenticode signing. See [docs/windows-release-trust.md](docs/windows-release-trust.md) for build commands, signature checks, and the release-trust checklist.
+
 ---
 
 ## Support the project!

--- a/docs/windows-release-trust.md
+++ b/docs/windows-release-trust.md
@@ -1,0 +1,87 @@
+# Windows Release Trust
+
+## What SmartScreen Is
+
+Windows Defender SmartScreen uses reputation signals for downloaded apps and installers. A GitHub-downloaded Windows installer can trigger `Windows protected your PC` when the file is unsigned or does not yet have enough reputation.
+
+## What This Repo Already Uses
+
+This repository already uses Tauri updater signatures for update metadata and updater artifacts. That is separate from Windows Authenticode signing.
+
+The updater signing flow uses the Tauri updater key configured for releases, typically through `TAURI_SIGNING_PRIVATE_KEY`. That protects the updater channel, but it does not remove SmartScreen warnings for a Windows installer downloaded from GitHub Releases.
+
+## Unsigned Build Path
+
+Build the app with the default configuration:
+
+```powershell
+npm exec tauri build
+```
+
+Expected outcome:
+
+- the build should succeed
+- the generated installer or executable may still be `NotSigned`
+- SmartScreen warnings may still appear for downloaded installers
+
+## Optional Signed Build Path
+
+Build the app with the Windows signing overlay:
+
+```powershell
+.\node_modules\.bin\tauri.cmd build --config src-tauri/tauri.windows.signing.conf.json
+```
+
+Required environment variables for `trusted-signing-cli` mode:
+
+- `BLUR_WINDOWS_SIGNING_MODE=trusted-signing-cli`
+- `BLUR_TRUSTED_SIGNING_ENDPOINT`
+- `BLUR_TRUSTED_SIGNING_ACCOUNT`
+- `BLUR_TRUSTED_SIGNING_PROFILE`
+- `BLUR_TRUSTED_SIGNING_DESCRIPTION` optional, defaults to `BlurAutoClicker`
+- `AZURE_CLIENT_ID`
+- `AZURE_CLIENT_SECRET`
+- `AZURE_TENANT_ID`
+
+Expected outcome once valid signing credentials exist:
+
+- the wrapper calls `trusted-signing-cli`
+- signed artifacts can be produced
+- SmartScreen behavior may improve, but this is not guaranteed by the repo alone
+
+If `BLUR_WINDOWS_SIGNING_MODE` is unset or set to `none`, the wrapper exits successfully without signing so the build can still complete.
+
+## Verify Signature State
+
+Check the built installer:
+
+```powershell
+Get-AuthenticodeSignature src-tauri\target\release\bundle\nsis\BlurAutoClicker_3.4.0_x64-setup.exe
+```
+
+Check the built executable:
+
+```powershell
+Get-AuthenticodeSignature src-tauri\target\release\BlurAutoClicker.exe
+```
+
+`NotSigned` is expected for unsigned builds. `Valid` is the expected status after successful Authenticode signing.
+
+## Best-Effort Post-Release Steps
+
+After publishing a release:
+
+1. Download the exact release asset that users will receive.
+2. Verify its signature state with `Get-AuthenticodeSignature`.
+3. If the file is unsigned or newly signed, submit the release asset to Microsoft Security Intelligence for analysis: <https://www.microsoft.com/en-us/wdsi/filesubmission>
+4. Monitor user reports and SmartScreen behavior after release.
+
+Submitting a file for analysis is best effort. It does not guarantee SmartScreen warnings will disappear.
+
+## Release Checklist
+
+1. Build the release with `npm exec tauri build` or `.\node_modules\.bin\tauri.cmd build --config src-tauri/tauri.windows.signing.conf.json`.
+2. Verify installer and executable signature state.
+3. Test the installer on a clean Windows machine or VM.
+4. Publish the release asset.
+5. Submit the published asset for Microsoft analysis if the file is unsigned or newly signed.

--- a/scripts/sign-windows.ps1
+++ b/scripts/sign-windows.ps1
@@ -1,0 +1,58 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $ArtifactPath)) {
+    Write-Error "Artifact not found: $ArtifactPath"
+}
+
+$resolvedArtifactPath = (Resolve-Path -LiteralPath $ArtifactPath).Path
+$mode = $env:BLUR_WINDOWS_SIGNING_MODE
+
+if ([string]::IsNullOrWhiteSpace($mode) -or $mode -eq "none") {
+    Write-Host "Skipping Windows signing for $resolvedArtifactPath"
+    exit 0
+}
+
+if ($mode -ne "trusted-signing-cli") {
+    Write-Error "Unsupported BLUR_WINDOWS_SIGNING_MODE '$mode'. Supported values: none, trusted-signing-cli."
+}
+
+$requiredEnvVars = @(
+    "BLUR_TRUSTED_SIGNING_ENDPOINT",
+    "BLUR_TRUSTED_SIGNING_ACCOUNT",
+    "BLUR_TRUSTED_SIGNING_PROFILE",
+    "AZURE_CLIENT_ID",
+    "AZURE_CLIENT_SECRET",
+    "AZURE_TENANT_ID"
+)
+
+$missingEnvVars = foreach ($envVar in $requiredEnvVars) {
+    $value = [Environment]::GetEnvironmentVariable($envVar)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        $envVar
+    }
+}
+
+if ($missingEnvVars.Count -gt 0) {
+    Write-Error ("Missing required environment variables for trusted-signing-cli: " + ($missingEnvVars -join ", "))
+}
+
+$description = if ([string]::IsNullOrWhiteSpace($env:BLUR_TRUSTED_SIGNING_DESCRIPTION)) {
+    "BlurAutoClicker"
+} else {
+    $env:BLUR_TRUSTED_SIGNING_DESCRIPTION
+}
+
+& trusted-signing-cli `
+    -e $env:BLUR_TRUSTED_SIGNING_ENDPOINT `
+    -a $env:BLUR_TRUSTED_SIGNING_ACCOUNT `
+    -c $env:BLUR_TRUSTED_SIGNING_PROFILE `
+    -d $description `
+    $resolvedArtifactPath
+
+exit $LASTEXITCODE

--- a/src-tauri/tauri.windows.signing.conf.json
+++ b/src-tauri/tauri.windows.signing.conf.json
@@ -1,0 +1,17 @@
+{
+  "bundle": {
+    "windows": {
+      "signCommand": {
+        "cmd": "powershell.exe",
+        "args": [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "../scripts/sign-windows.ps1",
+          "%1"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- base this work on current upstream `main` without touching open feature PR areas
- add an optional Windows signing overlay and PowerShell wrapper so future releases can be Authenticode-signed without changing app behavior
- document the current SmartScreen limitation for unsigned GitHub-downloaded installers
- add a release-trust checklist covering signature verification and Microsoft file submission as best effort

## Why
The current Windows installer is unsigned, so SmartScreen warnings for browser-downloaded releases are expected. This PR does not attempt a bypass. It adds the smallest practical repo changes needed to support future signing and to document the unsigned-release path accurately.

## Scope
- no runtime feature changes
- no settings schema changes
- no hotkey, tray, i18n, packaging-target, or CI feature work
- no edits to the main `src-tauri/tauri.conf.json`

## Validation
- `npm run lint`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm exec tauri build` with a temporary local updater signing key injected through `TAURI_SIGNING_PRIVATE_KEY`
- `.\node_modules\.bin\tauri.cmd build --config src-tauri/tauri.windows.signing.conf.json` with `BLUR_WINDOWS_SIGNING_MODE=none`
- `Get-AuthenticodeSignature` on the built installer and executable, both confirmed `NotSigned`
- negative-path validation of `trusted-signing-cli` mode with missing env vars, confirming the wrapper fails with a clear missing-variable error

## Notes
- the repository's existing updater public key still requires a private key at build time for updater artifacts, so local validation used a throwaway key outside the repo
- the npm form `npm exec tauri build -- --config ...` forwarded `--config` incorrectly with the current npm/Tauri combination, so the overlay validation used the local Tauri CLI directly
