### PR TITLE
feat: explain unavailable controls on hover

### DIFF
--- a/src/components/UnavailableReason.css
+++ b/src/components/UnavailableReason.css
@@ -1,4 +1,10 @@
 .unavailable-reason {
+  --unavailable-reason-offset-x: 0px;
+  --unavailable-reason-surface: color-mix(
+    in srgb,
+    var(--bg-surface) 92%,
+    black 8%
+  );
   position: relative;
   display: inline-flex;
   max-width: 100%;
@@ -12,13 +18,14 @@
   position: absolute;
   left: 50%;
   bottom: calc(100% + 8px);
-  transform: translateX(-50%) translateY(4px);
+  transform: translateX(calc(-50% + var(--unavailable-reason-offset-x)))
+    translateY(4px);
   width: max-content;
   max-width: min(260px, calc(100vw - 48px));
   padding: 8px 10px;
   border: 1px solid var(--border-focus);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--bg-surface) 92%, black 8%);
+  background: var(--unavailable-reason-surface);
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
   color: var(--text-primary);
   font-family: 'DMSans', sans-serif;
@@ -39,14 +46,35 @@
   top: 100%;
   width: 8px;
   height: 8px;
-  background: color-mix(in srgb, var(--bg-surface) 92%, black 8%);
+  background: var(--unavailable-reason-surface);
   border-right: 1px solid var(--border-focus);
   border-bottom: 1px solid var(--border-focus);
   transform: translateX(-50%) rotate(45deg);
 }
 
-.unavailable-reason:hover .unavailable-reason-tooltip,
-.unavailable-reason:focus-within .unavailable-reason-tooltip {
+.unavailable-reason[data-placement="below"] .unavailable-reason-tooltip {
+  top: calc(100% + 8px);
+  bottom: auto;
+  transform: translateX(calc(-50% + var(--unavailable-reason-offset-x)))
+    translateY(-4px);
+}
+
+.unavailable-reason[data-placement="below"] .unavailable-reason-tooltip::after {
+  top: auto;
+  bottom: 100%;
+  border-right: 1px solid var(--border-focus);
+  border-bottom: 1px solid var(--border-focus);
+  transform: translateX(-50%) rotate(225deg);
+}
+
+.unavailable-reason[data-open="true"] .unavailable-reason-tooltip {
   opacity: 1;
-  transform: translateX(-50%) translateY(0);
+  transform: translateX(calc(-50% + var(--unavailable-reason-offset-x)))
+    translateY(0);
+}
+
+.unavailable-reason[data-open="true"][data-placement="below"]
+  .unavailable-reason-tooltip {
+  transform: translateX(calc(-50% + var(--unavailable-reason-offset-x)))
+    translateY(0);
 }

--- a/src/components/UnavailableReason.css
+++ b/src/components/UnavailableReason.css
@@ -1,0 +1,52 @@
+.unavailable-reason {
+  position: relative;
+  display: inline-flex;
+  max-width: 100%;
+}
+
+.unavailable-reason--block {
+  display: block;
+}
+
+.unavailable-reason-tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%) translateY(4px);
+  width: max-content;
+  max-width: min(260px, calc(100vw - 48px));
+  padding: 8px 10px;
+  border: 1px solid var(--border-focus);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-surface) 92%, black 8%);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
+  color: var(--text-primary);
+  font-family: 'DMSans', sans-serif;
+  font-size: 11px;
+  font-weight: var(--font-weight-md);
+  line-height: 1.35;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 30;
+}
+
+.unavailable-reason-tooltip::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  width: 8px;
+  height: 8px;
+  background: color-mix(in srgb, var(--bg-surface) 92%, black 8%);
+  border-right: 1px solid var(--border-focus);
+  border-bottom: 1px solid var(--border-focus);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.unavailable-reason:hover .unavailable-reason-tooltip,
+.unavailable-reason:focus-within .unavailable-reason-tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}

--- a/src/components/UnavailableReason.tsx
+++ b/src/components/UnavailableReason.tsx
@@ -1,4 +1,11 @@
-import type { ReactNode } from "react";
+import {
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import "./UnavailableReason.css";
 
 interface Props {
@@ -7,19 +14,101 @@ interface Props {
   className?: string;
 }
 
+type TooltipStyle = CSSProperties & {
+  "--unavailable-reason-offset-x": string;
+};
+
 export default function UnavailableReason({
   reason,
   children,
   className,
 }: Props) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [placement, setPlacement] = useState<"above" | "below">("above");
+  const [tooltipStyle, setTooltipStyle] = useState<TooltipStyle>({
+    "--unavailable-reason-offset-x": "0px",
+  });
+
+  const updateTooltipPosition = useEffectEvent(() => {
+    const wrapper = wrapperRef.current;
+    const tooltip = tooltipRef.current;
+
+    if (!wrapper || !tooltip) {
+      return;
+    }
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const tooltipGap = 8;
+    const viewportPadding = 8;
+    const titleBarClearance = 52;
+    const topSpace = wrapperRect.top - titleBarClearance;
+    const shouldPlaceBelow = topSpace < tooltipRect.height + tooltipGap;
+    const idealLeft =
+      wrapperRect.left + wrapperRect.width / 2 - tooltipRect.width / 2;
+    const minLeft = viewportPadding;
+    const maxLeft = Math.max(
+      viewportPadding,
+      window.innerWidth - tooltipRect.width - viewportPadding,
+    );
+    const clampedLeft = Math.min(Math.max(idealLeft, minLeft), maxLeft);
+    const offsetX = clampedLeft - idealLeft;
+
+    setPlacement(shouldPlaceBelow ? "below" : "above");
+    setTooltipStyle({
+      "--unavailable-reason-offset-x": `${offsetX}px`,
+    });
+  });
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    updateTooltipPosition();
+
+    const handleWindowChange = () => {
+      updateTooltipPosition();
+    };
+
+    window.addEventListener("resize", handleWindowChange);
+    window.addEventListener("scroll", handleWindowChange, true);
+
+    return () => {
+      window.removeEventListener("resize", handleWindowChange);
+      window.removeEventListener("scroll", handleWindowChange, true);
+    };
+  }, [open]);
+
   if (!reason) {
     return <>{children}</>;
   }
 
   return (
-    <div className={`unavailable-reason ${className ?? ""}`.trim()}>
+    <div
+      ref={wrapperRef}
+      className={`unavailable-reason ${className ?? ""}`.trim()}
+      data-open={open ? "true" : "false"}
+      data-placement={placement}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocusCapture={() => setOpen(true)}
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setOpen(false);
+        }
+      }}
+    >
       {children}
-      <div className="unavailable-reason-tooltip">{reason}</div>
+      <div
+        ref={tooltipRef}
+        className="unavailable-reason-tooltip"
+        style={tooltipStyle}
+      >
+        {reason}
+      </div>
     </div>
   );
 }

--- a/src/components/UnavailableReason.tsx
+++ b/src/components/UnavailableReason.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import "./UnavailableReason.css";
+
+interface Props {
+  reason?: string | null;
+  children: ReactNode;
+  className?: string;
+}
+
+export default function UnavailableReason({
+  reason,
+  children,
+  className,
+}: Props) {
+  if (!reason) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className={`unavailable-reason ${className ?? ""}`.trim()}>
+      {children}
+      <div className="unavailable-reason-tooltip">{reason}</div>
+    </div>
+  );
+}

--- a/src/components/Updatebanner.tsx
+++ b/src/components/Updatebanner.tsx
@@ -68,10 +68,10 @@ export default function UpdateBanner({
   const installDisabledReason =
     stage === "installing"
       ? statusKey === "update.installing"
-        ? "The update is already installing. Wait for it to finish before trying again."
+        ? t("update.installAlreadyInstalling")
         : statusKey === "update.downloading"
-          ? "The update is already downloading. Wait for the current install to finish."
-          : "The update is already being prepared. Wait for it to finish before trying again."
+          ? t("update.installAlreadyDownloading")
+          : t("update.installAlreadyPreparing")
       : undefined;
 
   return (

--- a/src/components/Updatebanner.tsx
+++ b/src/components/Updatebanner.tsx
@@ -2,6 +2,7 @@ import { relaunch } from "@tauri-apps/plugin-process";
 import { check } from "@tauri-apps/plugin-updater";
 import { useState } from "react";
 import { useTranslation, type TranslationKey } from "../i18n";
+import UnavailableReason from "./UnavailableReason";
 import "./Updatebanner.css";
 
 interface UpdateBannerProps {
@@ -64,6 +65,15 @@ export default function UpdateBanner({
     }
   };
 
+  const installDisabledReason =
+    stage === "installing"
+      ? statusKey === "update.installing"
+        ? "The update is already installing. Wait for it to finish before trying again."
+        : statusKey === "update.downloading"
+          ? "The update is already downloading. Wait for the current install to finish."
+          : "The update is already being prepared. Wait for it to finish before trying again."
+      : undefined;
+
   return (
     <div className="update-banner">
       <span className="update-banner-text-old-version">v{currentVersion}</span>
@@ -80,15 +90,17 @@ export default function UpdateBanner({
           {t("update.restartToApply")}
         </button>
       ) : (
-        <button
-          className="update-banner-btn"
-          onClick={handleUpdate}
-          disabled={stage === "installing"}
-        >
-          {stage === "installing"
-            ? t("update.installingButton")
-            : t("update.downloadAndInstall")}
-        </button>
+        <UnavailableReason reason={installDisabledReason}>
+          <button
+            className="update-banner-btn"
+            onClick={handleUpdate}
+            disabled={stage === "installing"}
+          >
+            {stage === "installing"
+              ? t("update.installingButton")
+              : t("update.downloadAndInstall")}
+          </button>
+        </UnavailableReason>
       )}
     </div>
   );

--- a/src/components/panels/AdvancedPanelLayout.tsx
+++ b/src/components/panels/AdvancedPanelLayout.tsx
@@ -10,7 +10,10 @@ import {
   type FocusEvent,
   type ReactNode,
 } from "react";
-import { getMaxDoubleClickDelayMs } from "../../cadence";
+import {
+  getEffectiveClicksPerSecond,
+  getMaxDoubleClickDelayMs,
+} from "../../cadence";
 import { normalizeIntegerRaw } from "../../numberInput";
 import type { SequencePoint, Settings } from "../../store";
 import { useTranslation, type TranslationKey } from "../../i18n";
@@ -21,6 +24,7 @@ import {
   TIME_LIMIT_UNIT_OPTIONS,
 } from "../../settingsSchema";
 import HotkeyCaptureInput from "../HotkeyCaptureInput";
+import UnavailableReason from "../UnavailableReason";
 
 interface Props {
   settings: Settings;
@@ -39,10 +43,12 @@ function ToggleBtn({
   value,
   onChange,
   disabled = false,
+  disabledReason,
 }: {
   value: boolean;
   onChange: (v: boolean) => void;
   disabled?: boolean;
+  disabledReason?: string;
 }) {
   const { t } = useTranslation();
 
@@ -52,7 +58,7 @@ function ToggleBtn({
     }
   }, [disabled, value, onChange]);
 
-  return (
+  const group = (
     <div className="adv-toggle-group">
       <button
         className={`adv-toggle-btn ${!value ? "active" : ""} ${disabled ? "disabled" : ""}`}
@@ -70,18 +76,26 @@ function ToggleBtn({
       </button>
     </div>
   );
+
+  return disabled ? (
+    <UnavailableReason reason={disabledReason}>{group}</UnavailableReason>
+  ) : (
+    group
+  );
 }
 
 function Disableable({
   enabled,
+  disabledReason,
   children,
 }: {
   enabled: boolean;
+  disabledReason?: string;
   children: ReactNode;
 }) {
   const { t } = useTranslation();
 
-  return (
+  const content = (
     <div className="disabled-container">
       <div className={enabled ? "" : "disabled-content"}>{children}</div>
       {!enabled && (
@@ -90,6 +104,17 @@ function Disableable({
         </div>
       )}
     </div>
+  );
+
+  return enabled ? (
+    content
+  ) : (
+    <UnavailableReason
+      reason={disabledReason}
+      className="unavailable-reason--block"
+    >
+      {content}
+    </UnavailableReason>
   );
 }
 
@@ -191,6 +216,19 @@ const EDGE_KEYS = {
   bottom: "edgeStopBottom",
 } as const;
 
+function formatClicksPerSecond(value: number): string {
+  if (value >= 10) {
+    return value.toFixed(value % 1 === 0 ? 0 : 1);
+  }
+
+  if (value >= 1) {
+    return value.toFixed(2).replace(/\.?0+$/, "");
+  }
+
+  return value.toFixed(3).replace(/\.?0+$/, "");
+}
+
+
 export default function AdvancedPanelLayout({
   settings,
   update,
@@ -242,6 +280,23 @@ export default function AdvancedPanelLayout({
 
   const showDesc = (key: TranslationKey) =>
     showExplanations ? <p className="adv-desc">{t(key)}</p> : null;
+  const currentClicksPerSecond = getEffectiveClicksPerSecond({
+    clickInterval,
+    clickSpeed,
+    rateInputMode,
+    durationMinutes,
+    durationSeconds,
+    durationMilliseconds,
+  });
+  const doubleClickDisabled = getMaxDoubleClickDelayMs(settings) <= 20;
+  const doubleClickDisabledReason = doubleClickDisabled
+    ? `Double Click is unavailable at ${formatClicksPerSecond(currentClicksPerSecond)} clicks/sec. Lower the effective click rate below 50 clicks/sec to turn it on.`
+    : undefined;
+  const pickPositionDisabledReason = pickingPosition
+    ? pickCountdown
+      ? `Position capture starts in ${pickCountdown} second${pickCountdown === 1 ? "" : "s"}. Move your cursor to the target spot and wait for it to be saved.`
+      : "Position capture is already in progress. Wait for the current pick to finish."
+    : undefined;
 
   const requestCursorPosition = async (): Promise<CursorPoint> => {
     setCapturingCursor(true);
@@ -446,7 +501,10 @@ export default function AdvancedPanelLayout({
               <div className="adv-card-header">
                 <span className="adv-card-title">{t("advanced.speedVariation")}</span>
                 <div className="adv-row" style={{ gap: 8 }}>
-                  <Disableable enabled={settings.speedVariationEnabled}>
+                  <Disableable
+                    enabled={settings.speedVariationEnabled}
+                    disabledReason="Enable Speed Variation to edit how much the app randomizes your click timing."
+                  >
                     <div className="adv-numbox-sm">
                       <NumInput
                         value={settings.speedVariation}
@@ -463,7 +521,10 @@ export default function AdvancedPanelLayout({
                   />
                 </div>
               </div>
-              <Disableable enabled={settings.speedVariationEnabled}>
+              <Disableable
+                enabled={settings.speedVariationEnabled}
+                disabledReason="Enable Speed Variation to edit how much the app randomizes your click timing."
+              >
                 {showDesc("advanced.speedVariationDescription")}
               </Disableable>
             </div>
@@ -486,11 +547,15 @@ export default function AdvancedPanelLayout({
                   <ToggleBtn
                     value={settings.doubleClickEnabled}
                     onChange={(v) => update({ doubleClickEnabled: v })}
-                    disabled={getMaxDoubleClickDelayMs(settings) <= 20}
+                    disabled={doubleClickDisabled}
+                    disabledReason={doubleClickDisabledReason}
                   />
                 </div>
               </div>
-              <Disableable enabled={settings.doubleClickEnabled}>
+              <Disableable
+                enabled={settings.doubleClickEnabled}
+                disabledReason="Enable Double Click to adjust the delay between the first and second click."
+              >
                 {showDesc("advanced.doubleClickDescription")}
               </Disableable>
             </div>
@@ -540,7 +605,10 @@ export default function AdvancedPanelLayout({
               >
                 <span className="adv-card-title">{t("advanced.clickLimit")}</span>
                 <div className="adv-row" style={{ gap: 6 }}>
-                  <Disableable enabled={settings.clickLimitEnabled}>
+                  <Disableable
+                    enabled={settings.clickLimitEnabled}
+                    disabledReason="Enable Click Limit to stop automatically after a set number of clicks."
+                  >
                     <div className="adv-numbox-sm">
                       <NumInput
                         value={settings.clickLimit}
@@ -564,7 +632,10 @@ export default function AdvancedPanelLayout({
               >
                 <span className="adv-card-title">{t("advanced.timeLimit")}</span>
                 <div className="adv-row" style={{ gap: 6 }}>
-                  <Disableable enabled={settings.timeLimitEnabled}>
+                  <Disableable
+                    enabled={settings.timeLimitEnabled}
+                    disabledReason="Enable Time Limit to stop automatically after a set amount of time."
+                  >
                     <div className="adv-row" style={{ gap: 6 }}>
                       <div className="adv-numbox-sm">
                         <NumInput
@@ -606,7 +677,10 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <CardDivider />
-              <Disableable enabled={settings.cornerStopEnabled}>
+              <Disableable
+                enabled={settings.cornerStopEnabled}
+                disabledReason="Enable Corner Stop to edit the corner failsafe hitboxes."
+              >
                 <div className="adv-row" style={{ gap: 8 }}>
                   {showExplanations && (
                     <p className="adv-desc">
@@ -645,7 +719,10 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <CardDivider />
-              <Disableable enabled={settings.edgeStopEnabled}>
+              <Disableable
+                enabled={settings.edgeStopEnabled}
+                disabledReason="Enable Edge Stop to edit the edge failsafe hitboxes."
+              >
                 <div className="adv-row" style={{ gap: 8 }}>
                   {showExplanations && (
                     <p className="adv-desc">
@@ -687,7 +764,10 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <CardDivider />
-              <Disableable enabled={settings.positionEnabled}>
+              <Disableable
+                enabled={settings.positionEnabled}
+                disabledReason="Enable Position to edit or pick a fixed cursor target before each click."
+              >
                 <div className="adv-row" style={{ marginTop: 8, gap: 6 }}>
                   {showExplanations && (
                     <p className="adv-desc">
@@ -744,17 +824,19 @@ export default function AdvancedPanelLayout({
                         />
                       </div>
                     </div>
-                    <button
-                      className="adv-pick-btn"
-                      onClick={handlePickPosition}
-                      disabled={pickingPosition}
-                    >
-                      {pickCountdown
-                        ? t("advanced.pickingIn", { seconds: pickCountdown })
-                        : pickingPosition
-                          ? t("advanced.picking")
-                          : t("advanced.pick")}
-                    </button>
+                    <UnavailableReason reason={pickPositionDisabledReason}>
+                      <button
+                        className="adv-pick-btn"
+                        onClick={handlePickPosition}
+                        disabled={pickingPosition}
+                      >
+                        {pickCountdown
+                          ? t("advanced.pickingIn", { seconds: pickCountdown })
+                          : pickingPosition
+                            ? t("advanced.picking")
+                            : t("advanced.pick")}
+                      </button>
+                    </UnavailableReason>
                   </div>
                 </div>
               </Disableable>
@@ -895,10 +977,14 @@ export default function AdvancedPanelLayout({
                 <ToggleBtn
                   value={settings.doubleClickEnabled}
                   onChange={(v) => update({ doubleClickEnabled: v })}
-                  disabled={getMaxDoubleClickDelayMs(settings) <= 20}
+                  disabled={doubleClickDisabled}
+                  disabledReason={doubleClickDisabledReason}
                 />
               </div>
-              <Disableable enabled={settings.doubleClickEnabled}>
+              <Disableable
+                enabled={settings.doubleClickEnabled}
+                disabledReason="Enable Double Click to adjust the delay between the first and second click."
+              >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start">
                     <div className="adv-numbox-sm">
@@ -933,7 +1019,10 @@ export default function AdvancedPanelLayout({
               />
             </div>
             <CardDivider />
-            <Disableable enabled={settings.positionEnabled}>
+            <Disableable
+              enabled={settings.positionEnabled}
+              disabledReason="Enable Position to edit or pick a fixed cursor target before each click."
+            >
               <div className={featureBodyClass}>
                 <div className="adv-inline-controls adv-inline-controls-start adv-position-inline">
                   <div
@@ -960,17 +1049,19 @@ export default function AdvancedPanelLayout({
                       style={{ width: "32px" }}
                     />
                   </div>
-                  <button
-                    className="adv-pick-btn adv-pick-btn-inline"
-                    onClick={handlePickPosition}
-                    disabled={pickingPosition}
-                  >
-                    {pickCountdown
-                      ? t("advanced.pickingIn", { seconds: pickCountdown })
-                      : pickingPosition
-                        ? t("advanced.picking")
-                        : t("advanced.pick")}
-                  </button>
+                  <UnavailableReason reason={pickPositionDisabledReason}>
+                    <button
+                      className="adv-pick-btn adv-pick-btn-inline"
+                      onClick={handlePickPosition}
+                      disabled={pickingPosition}
+                    >
+                      {pickCountdown
+                        ? t("advanced.pickingIn", { seconds: pickCountdown })
+                        : pickingPosition
+                          ? t("advanced.picking")
+                          : t("advanced.pick")}
+                    </button>
+                  </UnavailableReason>
                 </div>
               </div>
             </Disableable>
@@ -1080,7 +1171,10 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <CardDivider />
-              <Disableable enabled={settings.clickLimitEnabled}>
+              <Disableable
+                enabled={settings.clickLimitEnabled}
+                disabledReason="Enable Click Limit to stop automatically after a set number of clicks."
+              >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start adv-limit-inputs">
                     <div className="adv-numbox-sm">
@@ -1107,7 +1201,10 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <CardDivider />
-              <Disableable enabled={settings.timeLimitEnabled}>
+              <Disableable
+                enabled={settings.timeLimitEnabled}
+                disabledReason="Enable Time Limit to stop automatically after a set amount of time."
+              >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start adv-limit-inputs">
                     <div className="adv-numbox-sm">
@@ -1143,7 +1240,10 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <CardDivider />
-              <Disableable enabled={settings.dutyCycleEnabled}>
+              <Disableable
+                enabled={settings.dutyCycleEnabled}
+                disabledReason="Enable Duty Cycle to edit how long each click is held."
+              >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start">
                     <div className="adv-minmax">
@@ -1173,7 +1273,10 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <CardDivider />
-              <Disableable enabled={settings.speedVariationEnabled}>
+              <Disableable
+                enabled={settings.speedVariationEnabled}
+                disabledReason="Enable Speed Variation to edit how much the app randomizes your click timing."
+              >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start">
                     <div className="adv-numbox-sm">
@@ -1201,7 +1304,10 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <CardDivider />
-              <Disableable enabled={settings.cornerStopEnabled}>
+              <Disableable
+                enabled={settings.cornerStopEnabled}
+                disabledReason="Enable Corner Stop to edit the corner failsafe hitboxes."
+              >
                 <div className={featureBodyClass}>
                   <div className="adv-corner-grid">
                     {(["tl", "tr", "bl", "br"] as const).map((cornerKey) => (
@@ -1235,7 +1341,10 @@ export default function AdvancedPanelLayout({
                 />
               </div>
               <CardDivider />
-              <Disableable enabled={settings.edgeStopEnabled}>
+              <Disableable
+                enabled={settings.edgeStopEnabled}
+                disabledReason="Enable Edge Stop to edit the edge failsafe hitboxes."
+              >
                 <div className={featureBodyClass}>
                   <div className="adv-corner-grid">
                     {(["top", "right", "left", "bottom"] as const).map((edgeSide) => (

--- a/src/components/panels/AdvancedPanelLayout.tsx
+++ b/src/components/panels/AdvancedPanelLayout.tsx
@@ -290,12 +290,17 @@ export default function AdvancedPanelLayout({
   });
   const doubleClickDisabled = getMaxDoubleClickDelayMs(settings) <= 20;
   const doubleClickDisabledReason = doubleClickDisabled
-    ? `Double Click is unavailable at ${formatClicksPerSecond(currentClicksPerSecond)} clicks/sec. Lower the effective click rate below 50 clicks/sec to turn it on.`
+    ? t("advanced.doubleClickUnavailable", { cps: formatClicksPerSecond(currentClicksPerSecond) })
     : undefined;
   const pickPositionDisabledReason = pickingPosition
     ? pickCountdown
-      ? `Position capture starts in ${pickCountdown} second${pickCountdown === 1 ? "" : "s"}. Move your cursor to the target spot and wait for it to be saved.`
-      : "Position capture is already in progress. Wait for the current pick to finish."
+      ? t(
+          pickCountdown === 1
+            ? "advanced.pickCountdownSingularUnavailable"
+            : "advanced.pickCountdownUnavailable",
+          { seconds: pickCountdown },
+        )
+      : t("advanced.pickInProgressUnavailable")
     : undefined;
 
   const requestCursorPosition = async (): Promise<CursorPoint> => {
@@ -503,7 +508,7 @@ export default function AdvancedPanelLayout({
                 <div className="adv-row" style={{ gap: 8 }}>
                   <Disableable
                     enabled={settings.speedVariationEnabled}
-                    disabledReason="Enable Speed Variation to edit how much the app randomizes your click timing."
+                    disabledReason={t("advanced.speedVariationUnavailable")}
                   >
                     <div className="adv-numbox-sm">
                       <NumInput
@@ -523,7 +528,7 @@ export default function AdvancedPanelLayout({
               </div>
               <Disableable
                 enabled={settings.speedVariationEnabled}
-                disabledReason="Enable Speed Variation to edit how much the app randomizes your click timing."
+                disabledReason={t("advanced.speedVariationUnavailable")}
               >
                 {showDesc("advanced.speedVariationDescription")}
               </Disableable>
@@ -554,7 +559,7 @@ export default function AdvancedPanelLayout({
               </div>
               <Disableable
                 enabled={settings.doubleClickEnabled}
-                disabledReason="Enable Double Click to adjust the delay between the first and second click."
+                disabledReason={t("advanced.doubleClickContentUnavailable")}
               >
                 {showDesc("advanced.doubleClickDescription")}
               </Disableable>
@@ -607,7 +612,7 @@ export default function AdvancedPanelLayout({
                 <div className="adv-row" style={{ gap: 6 }}>
                   <Disableable
                     enabled={settings.clickLimitEnabled}
-                    disabledReason="Enable Click Limit to stop automatically after a set number of clicks."
+                    disabledReason={t("advanced.clickLimitUnavailable")}
                   >
                     <div className="adv-numbox-sm">
                       <NumInput
@@ -634,7 +639,7 @@ export default function AdvancedPanelLayout({
                 <div className="adv-row" style={{ gap: 6 }}>
                   <Disableable
                     enabled={settings.timeLimitEnabled}
-                    disabledReason="Enable Time Limit to stop automatically after a set amount of time."
+                    disabledReason={t("advanced.timeLimitUnavailable")}
                   >
                     <div className="adv-row" style={{ gap: 6 }}>
                       <div className="adv-numbox-sm">
@@ -679,7 +684,7 @@ export default function AdvancedPanelLayout({
               <CardDivider />
               <Disableable
                 enabled={settings.cornerStopEnabled}
-                disabledReason="Enable Corner Stop to edit the corner failsafe hitboxes."
+                disabledReason={t("advanced.cornerStopUnavailable")}
               >
                 <div className="adv-row" style={{ gap: 8 }}>
                   {showExplanations && (
@@ -721,7 +726,7 @@ export default function AdvancedPanelLayout({
               <CardDivider />
               <Disableable
                 enabled={settings.edgeStopEnabled}
-                disabledReason="Enable Edge Stop to edit the edge failsafe hitboxes."
+                disabledReason={t("advanced.edgeStopUnavailable")}
               >
                 <div className="adv-row" style={{ gap: 8 }}>
                   {showExplanations && (
@@ -766,7 +771,7 @@ export default function AdvancedPanelLayout({
               <CardDivider />
               <Disableable
                 enabled={settings.positionEnabled}
-                disabledReason="Enable Position to edit or pick a fixed cursor target before each click."
+                disabledReason={t("advanced.positionUnavailable")}
               >
                 <div className="adv-row" style={{ marginTop: 8, gap: 6 }}>
                   {showExplanations && (
@@ -983,7 +988,7 @@ export default function AdvancedPanelLayout({
               </div>
               <Disableable
                 enabled={settings.doubleClickEnabled}
-                disabledReason="Enable Double Click to adjust the delay between the first and second click."
+                disabledReason={t("advanced.doubleClickContentUnavailable")}
               >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start">
@@ -1021,7 +1026,7 @@ export default function AdvancedPanelLayout({
             <CardDivider />
             <Disableable
               enabled={settings.positionEnabled}
-              disabledReason="Enable Position to edit or pick a fixed cursor target before each click."
+              disabledReason={t("advanced.positionUnavailable")}
             >
               <div className={featureBodyClass}>
                 <div className="adv-inline-controls adv-inline-controls-start adv-position-inline">
@@ -1173,7 +1178,7 @@ export default function AdvancedPanelLayout({
               <CardDivider />
               <Disableable
                 enabled={settings.clickLimitEnabled}
-                disabledReason="Enable Click Limit to stop automatically after a set number of clicks."
+                disabledReason={t("advanced.clickLimitUnavailable")}
               >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start adv-limit-inputs">
@@ -1203,7 +1208,7 @@ export default function AdvancedPanelLayout({
               <CardDivider />
               <Disableable
                 enabled={settings.timeLimitEnabled}
-                disabledReason="Enable Time Limit to stop automatically after a set amount of time."
+                disabledReason={t("advanced.timeLimitUnavailable")}
               >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start adv-limit-inputs">
@@ -1242,7 +1247,7 @@ export default function AdvancedPanelLayout({
               <CardDivider />
               <Disableable
                 enabled={settings.dutyCycleEnabled}
-                disabledReason="Enable Duty Cycle to edit how long each click is held."
+                disabledReason={t("advanced.dutyCycleUnavailable")}
               >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start">
@@ -1275,7 +1280,7 @@ export default function AdvancedPanelLayout({
               <CardDivider />
               <Disableable
                 enabled={settings.speedVariationEnabled}
-                disabledReason="Enable Speed Variation to edit how much the app randomizes your click timing."
+                disabledReason={t("advanced.speedVariationUnavailable")}
               >
                 <div className={cardBodyClass}>
                   <div className="adv-inline-controls adv-inline-controls-start">
@@ -1306,7 +1311,7 @@ export default function AdvancedPanelLayout({
               <CardDivider />
               <Disableable
                 enabled={settings.cornerStopEnabled}
-                disabledReason="Enable Corner Stop to edit the corner failsafe hitboxes."
+                disabledReason={t("advanced.cornerStopUnavailable")}
               >
                 <div className={featureBodyClass}>
                   <div className="adv-corner-grid">
@@ -1343,7 +1348,7 @@ export default function AdvancedPanelLayout({
               <CardDivider />
               <Disableable
                 enabled={settings.edgeStopEnabled}
-                disabledReason="Enable Edge Stop to edit the edge failsafe hitboxes."
+                disabledReason={t("advanced.edgeStopUnavailable")}
               >
                 <div className={featureBodyClass}>
                   <div className="adv-corner-grid">

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -115,7 +115,19 @@
     "customStopZone": "منطقة إيقاف مخصصة",
     "customStopZoneDescription": "توقف أداة النقر عندما يدخل المؤشر هذه المنطقة المستطيلة باستخدام إحداثيات مطلقة قد تمتد عبر عدة شاشات.",
     "customStopZoneSetTopLeft": "تحديد أعلى اليسار",
-    "customStopZoneSetBottomRight": "تحديد أسفل اليمين"
+    "customStopZoneSetBottomRight": "تحديد أسفل اليمين",
+    "speedVariationUnavailable": "Enable Speed Variation to edit how much the app randomizes your click timing.",
+    "doubleClickUnavailable": "Double Click is unavailable at {cps} clicks/sec. Lower the effective click rate below 50 clicks/sec to turn it on.",
+    "doubleClickContentUnavailable": "Enable Double Click to adjust the delay between the first and second click.",
+    "clickLimitUnavailable": "Enable Click Limit to stop automatically after a set number of clicks.",
+    "timeLimitUnavailable": "Enable Time Limit to stop automatically after a set amount of time.",
+    "cornerStopUnavailable": "Enable Corner Stop to edit the corner failsafe hitboxes.",
+    "edgeStopUnavailable": "Enable Edge Stop to edit the edge failsafe hitboxes.",
+    "positionUnavailable": "Enable Position to edit or pick a fixed cursor target before each click.",
+    "dutyCycleUnavailable": "Enable Duty Cycle to edit how long each click is held.",
+    "pickInProgressUnavailable": "Position capture is already in progress. Wait for the current pick to finish.",
+    "pickCountdownUnavailable": "Position capture starts in {seconds} seconds. Move your cursor to the target spot and wait for it to be saved.",
+    "pickCountdownSingularUnavailable": "Position capture starts in 1 second. Move your cursor to the target spot and wait for it to be saved."
   },
   "options": {
     "interval": {
@@ -218,7 +230,10 @@
     "installFailed": "فشل تثبيت التحديث.",
     "restartFailed": "فشلت إعادة التشغيل. أعد فتح التطبيق يدويا.",
     "restartToApply": "إعادة التشغيل للتطبيق",
-    "downloadAndInstall": "تنزيل وتثبيت"
+    "downloadAndInstall": "تنزيل وتثبيت",
+    "installAlreadyInstalling": "The update is already installing. Wait for it to finish before trying again.",
+    "installAlreadyDownloading": "The update is already downloading. Wait for the current install to finish.",
+    "installAlreadyPreparing": "The update is already being prepared. Wait for it to finish before trying again."
   },
   "stopReason": {
     "stoppedFromUi": "تم الإيقاف من الواجهة",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -115,7 +115,19 @@
     "customStopZone": "Custom Stop Zone",
     "customStopZoneDescription": "Stops the clicker when the cursor enters this rectangular area, using absolute screen coordinates that can span multiple monitors.",
     "customStopZoneSetTopLeft": "Set Top-Left",
-    "customStopZoneSetBottomRight": "Set Bottom-Right"
+    "customStopZoneSetBottomRight": "Set Bottom-Right",
+    "speedVariationUnavailable": "Enable Speed Variation to edit how much the app randomizes your click timing.",
+    "doubleClickUnavailable": "Double Click is unavailable at {cps} clicks/sec. Lower the effective click rate below 50 clicks/sec to turn it on.",
+    "doubleClickContentUnavailable": "Enable Double Click to adjust the delay between the first and second click.",
+    "clickLimitUnavailable": "Enable Click Limit to stop automatically after a set number of clicks.",
+    "timeLimitUnavailable": "Enable Time Limit to stop automatically after a set amount of time.",
+    "cornerStopUnavailable": "Enable Corner Stop to edit the corner failsafe hitboxes.",
+    "edgeStopUnavailable": "Enable Edge Stop to edit the edge failsafe hitboxes.",
+    "positionUnavailable": "Enable Position to edit or pick a fixed cursor target before each click.",
+    "dutyCycleUnavailable": "Enable Duty Cycle to edit how long each click is held.",
+    "pickInProgressUnavailable": "Position capture is already in progress. Wait for the current pick to finish.",
+    "pickCountdownUnavailable": "Position capture starts in {seconds} seconds. Move your cursor to the target spot and wait for it to be saved.",
+    "pickCountdownSingularUnavailable": "Position capture starts in 1 second. Move your cursor to the target spot and wait for it to be saved."
   },
   "options": {
     "interval": {
@@ -218,7 +230,10 @@
     "installFailed": "Update install failed.",
     "restartFailed": "Restart failed. Please reopen the app manually.",
     "restartToApply": "Restart to Apply Update",
-    "downloadAndInstall": "Download and Install"
+    "downloadAndInstall": "Download and Install",
+    "installAlreadyInstalling": "The update is already installing. Wait for it to finish before trying again.",
+    "installAlreadyDownloading": "The update is already downloading. Wait for the current install to finish.",
+    "installAlreadyPreparing": "The update is already being prepared. Wait for it to finish before trying again."
   },
   "stopReason": {
     "stoppedFromUi": "Stopped from UI",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -115,7 +115,19 @@
     "customStopZone": "Zona de parada personalizada",
     "customStopZoneDescription": "Detiene el clicker cuando el cursor entra en esta zona rectangular usando coordenadas absolutas que pueden abarcar varios monitores.",
     "customStopZoneSetTopLeft": "Definir esquina sup. izq.",
-    "customStopZoneSetBottomRight": "Definir esquina inf. der."
+    "customStopZoneSetBottomRight": "Definir esquina inf. der.",
+    "speedVariationUnavailable": "Enable Speed Variation to edit how much the app randomizes your click timing.",
+    "doubleClickUnavailable": "Double Click is unavailable at {cps} clicks/sec. Lower the effective click rate below 50 clicks/sec to turn it on.",
+    "doubleClickContentUnavailable": "Enable Double Click to adjust the delay between the first and second click.",
+    "clickLimitUnavailable": "Enable Click Limit to stop automatically after a set number of clicks.",
+    "timeLimitUnavailable": "Enable Time Limit to stop automatically after a set amount of time.",
+    "cornerStopUnavailable": "Enable Corner Stop to edit the corner failsafe hitboxes.",
+    "edgeStopUnavailable": "Enable Edge Stop to edit the edge failsafe hitboxes.",
+    "positionUnavailable": "Enable Position to edit or pick a fixed cursor target before each click.",
+    "dutyCycleUnavailable": "Enable Duty Cycle to edit how long each click is held.",
+    "pickInProgressUnavailable": "Position capture is already in progress. Wait for the current pick to finish.",
+    "pickCountdownUnavailable": "Position capture starts in {seconds} seconds. Move your cursor to the target spot and wait for it to be saved.",
+    "pickCountdownSingularUnavailable": "Position capture starts in 1 second. Move your cursor to the target spot and wait for it to be saved."
   },
   "options": {
     "interval": {
@@ -218,7 +230,10 @@
     "installFailed": "No se pudo instalar la actualización.",
     "restartFailed": "No se pudo reiniciar. Vuelve a abrir la app manualmente.",
     "restartToApply": "Reiniciar para aplicar",
-    "downloadAndInstall": "Descargar e instalar"
+    "downloadAndInstall": "Descargar e instalar",
+    "installAlreadyInstalling": "The update is already installing. Wait for it to finish before trying again.",
+    "installAlreadyDownloading": "The update is already downloading. Wait for the current install to finish.",
+    "installAlreadyPreparing": "The update is already being prepared. Wait for it to finish before trying again."
   },
   "stopReason": {
     "stoppedFromUi": "Detenido desde la interfaz",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -115,7 +115,19 @@
     "customStopZone": "Zone d'arrêt personnalisée",
     "customStopZoneDescription": "Arrête le clicker lorsque le curseur entre dans cette zone rectangulaire, avec des coordonnées absolues pouvant couvrir plusieurs écrans.",
     "customStopZoneSetTopLeft": "Définir haut-gauche",
-    "customStopZoneSetBottomRight": "Définir bas-droite"
+    "customStopZoneSetBottomRight": "Définir bas-droite",
+    "speedVariationUnavailable": "Enable Speed Variation to edit how much the app randomizes your click timing.",
+    "doubleClickUnavailable": "Double Click is unavailable at {cps} clicks/sec. Lower the effective click rate below 50 clicks/sec to turn it on.",
+    "doubleClickContentUnavailable": "Enable Double Click to adjust the delay between the first and second click.",
+    "clickLimitUnavailable": "Enable Click Limit to stop automatically after a set number of clicks.",
+    "timeLimitUnavailable": "Enable Time Limit to stop automatically after a set amount of time.",
+    "cornerStopUnavailable": "Enable Corner Stop to edit the corner failsafe hitboxes.",
+    "edgeStopUnavailable": "Enable Edge Stop to edit the edge failsafe hitboxes.",
+    "positionUnavailable": "Enable Position to edit or pick a fixed cursor target before each click.",
+    "dutyCycleUnavailable": "Enable Duty Cycle to edit how long each click is held.",
+    "pickInProgressUnavailable": "Position capture is already in progress. Wait for the current pick to finish.",
+    "pickCountdownUnavailable": "Position capture starts in {seconds} seconds. Move your cursor to the target spot and wait for it to be saved.",
+    "pickCountdownSingularUnavailable": "Position capture starts in 1 second. Move your cursor to the target spot and wait for it to be saved."
   },
   "options": {
     "interval": {
@@ -218,7 +230,10 @@
     "installFailed": "Échec de l'installation de la mise à jour.",
     "restartFailed": "Échec du redémarrage. Rouvrez l'application manuellement.",
     "restartToApply": "Redémarrer pour appliquer",
-    "downloadAndInstall": "Télécharger et installer"
+    "downloadAndInstall": "Télécharger et installer",
+    "installAlreadyInstalling": "The update is already installing. Wait for it to finish before trying again.",
+    "installAlreadyDownloading": "The update is already downloading. Wait for the current install to finish.",
+    "installAlreadyPreparing": "The update is already being prepared. Wait for it to finish before trying again."
   },
   "stopReason": {
     "stoppedFromUi": "Arrêté depuis l'interface",


### PR DESCRIPTION
## Summary
- add small hover tooltips that explain why currently unavailable controls cannot be used
- replace the advanced panel's generic `Disabled` overlay with feature-specific reasons
- cover the advanced Double Click speed limit case plus other existing disabled or grayed-out controls that already have a clear reason in current `main`

## Included
- reason tooltips for disabled advanced-panel sections such as Speed Variation, Double Click delay, Click Limit, Time Limit, Position, Corner Stop, Edge Stop, and compact Duty Cycle
- a specific hover explanation when Double Click is unavailable because the current click speed is too high
- hover explanations for temporarily unavailable controls during active operations, including `Pick` while position capture is already running and the updater install button while an update is already being prepared/downloaded/installed
- a shared lightweight tooltip wrapper so the UX stays consistent across disabled buttons and grayed-out sections

## Scope
- no behavior changes to the click engine or settings model
- no new feature toggles or unrelated UI work
- no overlap with current open PR areas such as presets, sequence clicking, keyboard auto-press, i18n, tray support, packaging, or CI

## Validation
- `npm run lint`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`

## Notes
- `npm ci` could not be used on current upstream `main` because the checked-in lockfile is out of sync with `package.json`; local frontend validation used `npm install --no-package-lock` to avoid changing package metadata in this PR
- the existing Vite build still emits pre-existing Lightning CSS warnings about Tailwind at-rules on `main`; the build itself completes successfully
