### PR TITLE
Add structured GitHub issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,7 +46,6 @@ body:
       options:
         - Simple
         - Advanced
-        - Macro
         - Settings / General
         - Not sure
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,130 @@
+name: Bug report
+description: Report a reproducible problem in Blur Auto Clicker
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+        Please fill out the form as clearly as possible so the issue can be reproduced.
+
+  - type: input
+    id: version
+    attributes:
+      label: Blur Auto Clicker version
+      description: Example: 3.3.0
+      placeholder: 3.3.0
+    validations:
+      required: true
+
+  - type: input
+    id: windows_version
+    attributes:
+      label: Windows version
+      description: Example: Windows 11 24H2
+      placeholder: Windows 11 24H2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_type
+    attributes:
+      label: Installation type
+      options:
+        - Installed release build
+        - Built from source
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Affected mode
+      options:
+        - Simple
+        - Advanced
+        - Macro
+        - Settings / General
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mouse_button
+    attributes:
+      label: Mouse button
+      options:
+        - Left
+        - Right
+        - Middle
+        - Multiple
+        - Not sure / N/A
+    validations:
+      required: true
+
+  - type: dropdown
+    id: activation_mode
+    attributes:
+      label: Activation mode
+      options:
+        - Hold
+        - Toggle
+        - Not sure / N/A
+    validations:
+      required: true
+
+  - type: input
+    id: click_rate
+    attributes:
+      label: Click speed / rate
+      description: Include unit if relevant, for example 50 CPS or 120 clicks per minute
+      placeholder: 50 CPS
+
+  - type: textarea
+    id: affected_settings
+    attributes:
+      label: Relevant settings
+      description: List any settings that seem relevant, such as duty cycle, speed variation, double click, edge stop, corner stop, or position clicking
+      placeholder: |
+        Duty cycle enabled
+        Speed variation 40-60 CPS
+        Edge stop enabled
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Write clear steps so the bug can be reproduced reliably
+      placeholder: |
+        1. Open the app
+        2. Switch to Advanced mode
+        3. Set the click speed to ...
+        4. Start the clicker
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The clicker should ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add anything else that may help, such as screenshots, recordings, logs, or unusual system behavior
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Suggest a new feature or improvement for Blur Auto Clicker
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+        Please describe the problem or use case first, then the solution you would like to see.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do, and what is currently missing or inconvenient?
+      placeholder: I want to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or behavior you would like to see
+      placeholder: It would help if Blur Auto Clicker could ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - UI / UX
+        - Clicking engine
+        - Hotkeys
+        - Overlay
+        - Settings / Storage
+        - Installer / Updates
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional - describe any workaround or alternative you have considered
+      placeholder: I currently work around this by ...
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Optional - add mockups, references, screenshots, or anything else that helps explain the idea
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+Describe the change in a few sentences.
+
+## Related issue
+
+Link the related issue here, or write `N/A`.
+
+## Testing
+
+Describe how you tested this change.
+If you did not test it, explain why.
+
+## Checklist
+
+- [ ] I tested the change locally
+- [ ] I kept the change focused and relevant
+- [ ] I updated any related documentation if needed


### PR DESCRIPTION
## Summary

Add structured GitHub issue forms for bug reports and feature requests.
Disable blank issues so contributors use the provided templates.
Add a lightweight pull request template to standardize summaries, linked issues, and testing notes.

## Related issue

--

## Testing

Reviewed the generated YAML and Markdown files locally to confirm the template structure, required fields, and labels.
No runtime tests were run because this change only adds GitHub repository metadata files.

## Checklist

- [ ] I tested the change locally
- [x] I kept the change focused and relevant
- [x] I updated any related documentation if needed
