### PR TITLE
Feature/customizable theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,9 @@ import { CUSTOM_THEME_VAR_MAP, isLightColor } from "./utils/theme";
 function clearCustomTheme(root: HTMLElement) {
   for (const [, cssVar] of CUSTOM_THEME_VAR_MAP) root.style.removeProperty(cssVar);
   root.style.removeProperty("--theme-tint");
+  root.style.removeProperty("--theme-bg-image");
+  root.style.removeProperty("--theme-bg-opacity");
+  root.style.removeProperty("--theme-bg-blur");
 }
 
 function applyCustomTheme(root: HTMLElement, c: CustomThemeColors) {
@@ -36,6 +39,32 @@ function applyCustomTheme(root: HTMLElement, c: CustomThemeColors) {
     } else {
       root.style.removeProperty(cssVar);
     }
+  }
+  if (c.backgroundImage) {
+    root.style.setProperty("--theme-bg-image", `url("${c.backgroundImage}")`);
+    root.style.setProperty(
+      "--theme-bg-opacity",
+      String((c.backgroundOpacity ?? 30) / 100),
+    );
+    root.style.setProperty("--theme-bg-blur", `${c.backgroundBlur ?? 0}px`);
+  } else {
+    root.style.removeProperty("--theme-bg-image");
+    root.style.removeProperty("--theme-bg-opacity");
+    root.style.removeProperty("--theme-bg-blur");
+  }
+  const panelOpacity = c.panelOpacity ?? 100;
+  if (panelOpacity < 100) {
+    const tint = isLightColor(c.bgBase) ? "#000" : "#fff";
+    const surfaceSrc = c.bgSurface || `color-mix(in oklab, ${c.bgBase} 95%, ${tint})`;
+    const elevatedSrc = c.bgElevated || `color-mix(in oklab, ${c.bgBase} 90%, ${tint})`;
+    root.style.setProperty(
+      "--bg-surface",
+      `color-mix(in srgb, ${surfaceSrc} ${panelOpacity}%, transparent)`,
+    );
+    root.style.setProperty(
+      "--bg-elevated",
+      `color-mix(in srgb, ${elevatedSrc} ${panelOpacity}%, transparent)`,
+    );
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,8 @@ function applyCustomTheme(root: HTMLElement, c: CustomThemeColors) {
     root.style.removeProperty("--theme-bg-blur");
   }
   const panelOpacity = c.panelOpacity ?? 100;
+  // If panel opacity < 100, override --bg-surface and --bg-elevated that were
+  // already set by the loop above; transparency is applied via color-mix.
   if (panelOpacity < 100) {
     const tint = isLightColor(c.bgBase) ? "#000" : "#fff";
     const surfaceSrc = c.bgSurface || `color-mix(in oklab, ${c.bgBase} 95%, ${tint})`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,11 +13,71 @@ import {
   DEFAULT_SETTINGS,
   type AppInfo,
   type ClickerStatus,
+  type CustomThemeColors,
   type Settings,
   clearSavedSettings,
   loadSettings,
   saveSettings,
 } from "./store";
+
+function hexToRgb(hex: string): [number, number, number] | null {
+  const clean = hex.replace("#", "");
+  const full = clean.length === 3
+    ? clean.split("").map((c) => c + c).join("")
+    : clean;
+  if (full.length !== 6) return null;
+  const n = parseInt(full, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return "#" + [r, g, b].map((v) => Math.round(Math.max(0, Math.min(255, v))).toString(16).padStart(2, "0")).join("");
+}
+
+function lighten(hex: string, pct: number): string {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+  const [r, g, b] = rgb;
+  return rgbToHex(r + (255 - r) * pct, g + (255 - g) * pct, b + (255 - b) * pct);
+}
+
+const CUSTOM_THEME_VARS = [
+  "--bg-base", "--bg-surface", "--bg-elevated", "--bg-input", "--bg-input-off",
+  "--border", "--border-focus", "--border-subtle",
+  "--text-primary", "--text-muted", "--text-dim",
+  "--accent-green", "--accent-yellow", "--accent-red",
+  "--radius-sm", "--radius-md", "--radius-lg",
+  "--container-shadow", "--divider-color", "--status-success", "--status-error",
+];
+
+function clearCustomTheme(root: HTMLElement) {
+  for (const v of CUSTOM_THEME_VARS) root.style.removeProperty(v);
+}
+
+function applyCustomTheme(root: HTMLElement, c: CustomThemeColors) {
+  const bg = c.bgBase;
+  root.style.setProperty("--bg-base", bg);
+  root.style.setProperty("--bg-surface", c.bgSurface ?? lighten(bg, 0.05));
+  root.style.setProperty("--bg-elevated", c.bgElevated ?? lighten(bg, 0.10));
+  root.style.setProperty("--bg-input", c.bgInput ?? lighten(bg, 0.20));
+  root.style.setProperty("--bg-input-off", c.bgInputOff ?? lighten(bg, 0.15));
+  root.style.setProperty("--border", c.border ?? lighten(bg, 0.28));
+  root.style.setProperty("--border-focus", c.borderFocus ?? lighten(bg, 0.35));
+  root.style.setProperty("--border-subtle", c.borderSubtle ?? lighten(bg, 0.20));
+  root.style.setProperty("--text-primary", c.textPrimary);
+  root.style.setProperty("--text-muted", c.textMuted ?? c.textPrimary + "80");
+  root.style.setProperty("--text-dim", c.textDim ?? c.textPrimary + "40");
+  root.style.setProperty("--accent-green", c.accentGreen);
+  root.style.setProperty("--accent-yellow", c.accentYellow);
+  root.style.setProperty("--accent-red", c.accentRed);
+  root.style.setProperty("--radius-sm", c.radiusSm ?? "0.375rem");
+  root.style.setProperty("--radius-md", c.radiusMd ?? "0.625rem");
+  root.style.setProperty("--radius-lg", c.radiusLg ?? "0.875rem");
+  root.style.setProperty("--container-shadow", c.containerShadow ?? "0 2px 0.5rem rgba(0,0,0,0.3)");
+  root.style.setProperty("--divider-color", c.dividerColor ?? "rgba(255,255,255,0.25)");
+  root.style.setProperty("--status-success", c.statusSuccess ?? c.accentGreen);
+  root.style.setProperty("--status-error", c.statusError ?? c.accentRed);
+}
 
 const SimplePanel = lazy(() => import("./components/panels/SimplePanel"));
 const AdvancedPanel = lazy(() => import("./components/panels/AdvancedPanel"));
@@ -408,8 +468,15 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    document.documentElement.dataset.theme = settings.theme ?? "dark";
-  }, [settings.theme]);
+    const root = document.documentElement;
+    if (settings.theme === "custom") {
+      root.removeAttribute("data-theme");
+      applyCustomTheme(root, settings.customTheme);
+    } else {
+      clearCustomTheme(root);
+      root.dataset.theme = settings.theme ?? "dark";
+    }
+  }, [settings.theme, settings.customTheme]);
 
   const handleTabChange = (nextTab: Tab) => {
     setTab(nextTab);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,63 +20,23 @@ import {
   saveSettings,
 } from "./store";
 
-function hexToRgb(hex: string): [number, number, number] | null {
-  const clean = hex.replace("#", "");
-  const full = clean.length === 3
-    ? clean.split("").map((c) => c + c).join("")
-    : clean;
-  if (full.length !== 6) return null;
-  const n = parseInt(full, 16);
-  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
-}
-
-function rgbToHex(r: number, g: number, b: number): string {
-  return "#" + [r, g, b].map((v) => Math.round(Math.max(0, Math.min(255, v))).toString(16).padStart(2, "0")).join("");
-}
-
-function lighten(hex: string, pct: number): string {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return hex;
-  const [r, g, b] = rgb;
-  return rgbToHex(r + (255 - r) * pct, g + (255 - g) * pct, b + (255 - b) * pct);
-}
-
-const CUSTOM_THEME_VARS = [
-  "--bg-base", "--bg-surface", "--bg-elevated", "--bg-input", "--bg-input-off",
-  "--border", "--border-focus", "--border-subtle",
-  "--text-primary", "--text-muted", "--text-dim",
-  "--accent-green", "--accent-yellow", "--accent-red",
-  "--radius-sm", "--radius-md", "--radius-lg",
-  "--container-shadow", "--divider-color", "--status-success", "--status-error",
-];
+import { CUSTOM_THEME_VAR_MAP, isLightColor } from "./utils/theme";
 
 function clearCustomTheme(root: HTMLElement) {
-  for (const v of CUSTOM_THEME_VARS) root.style.removeProperty(v);
+  for (const [, cssVar] of CUSTOM_THEME_VAR_MAP) root.style.removeProperty(cssVar);
+  root.style.removeProperty("--theme-tint");
 }
 
 function applyCustomTheme(root: HTMLElement, c: CustomThemeColors) {
-  const bg = c.bgBase;
-  root.style.setProperty("--bg-base", bg);
-  root.style.setProperty("--bg-surface", c.bgSurface ?? lighten(bg, 0.05));
-  root.style.setProperty("--bg-elevated", c.bgElevated ?? lighten(bg, 0.10));
-  root.style.setProperty("--bg-input", c.bgInput ?? lighten(bg, 0.20));
-  root.style.setProperty("--bg-input-off", c.bgInputOff ?? lighten(bg, 0.15));
-  root.style.setProperty("--border", c.border ?? lighten(bg, 0.28));
-  root.style.setProperty("--border-focus", c.borderFocus ?? lighten(bg, 0.35));
-  root.style.setProperty("--border-subtle", c.borderSubtle ?? lighten(bg, 0.20));
-  root.style.setProperty("--text-primary", c.textPrimary);
-  root.style.setProperty("--text-muted", c.textMuted ?? c.textPrimary + "80");
-  root.style.setProperty("--text-dim", c.textDim ?? c.textPrimary + "40");
-  root.style.setProperty("--accent-green", c.accentGreen);
-  root.style.setProperty("--accent-yellow", c.accentYellow);
-  root.style.setProperty("--accent-red", c.accentRed);
-  root.style.setProperty("--radius-sm", c.radiusSm ?? "0.375rem");
-  root.style.setProperty("--radius-md", c.radiusMd ?? "0.625rem");
-  root.style.setProperty("--radius-lg", c.radiusLg ?? "0.875rem");
-  root.style.setProperty("--container-shadow", c.containerShadow ?? "0 2px 0.5rem rgba(0,0,0,0.3)");
-  root.style.setProperty("--divider-color", c.dividerColor ?? "rgba(255,255,255,0.25)");
-  root.style.setProperty("--status-success", c.statusSuccess ?? c.accentGreen);
-  root.style.setProperty("--status-error", c.statusError ?? c.accentRed);
+  root.style.setProperty("--theme-tint", isLightColor(c.bgBase) ? "#000" : "#fff");
+  for (const [key, cssVar] of CUSTOM_THEME_VAR_MAP) {
+    const val = c[key];
+    if (typeof val === "string" && val.length > 0) {
+      root.style.setProperty(cssVar, val);
+    } else {
+      root.style.removeProperty(cssVar);
+    }
+  }
 }
 
 const SimplePanel = lazy(() => import("./components/panels/SimplePanel"));
@@ -470,7 +430,7 @@ export default function App() {
   useEffect(() => {
     const root = document.documentElement;
     if (settings.theme === "custom") {
-      root.removeAttribute("data-theme");
+      root.dataset.theme = "custom";
       applyCustomTheme(root, settings.customTheme);
     } else {
       clearCustomTheme(root);

--- a/src/components/ColorPickerInput.tsx
+++ b/src/components/ColorPickerInput.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { splitHexAlpha, combineHexAlpha } from "../utils/theme";
 
 interface Props {
   label: string;
@@ -6,32 +7,54 @@ interface Props {
   onChange: (hex: string) => void;
   optional?: boolean;
   placeholder?: string;
+  allowAlpha?: boolean;
 }
 
-function toHex(color: string): string | null {
-  if (/^#[0-9a-fA-F]{6}$/.test(color)) return color;
-  if (/^#[0-9a-fA-F]{3}$/.test(color)) {
-    return "#" + color.slice(1).split("").map((c) => c + c).join("");
+function normalizeHex6(color: string): string | null {
+  const t = color.trim();
+  if (/^#[0-9a-fA-F]{6}$/.test(t)) return t.toLowerCase();
+  if (/^#[0-9a-fA-F]{3}$/.test(t)) {
+    return (
+      "#" +
+      t
+        .slice(1)
+        .split("")
+        .map((c) => c + c)
+        .join("")
+    ).toLowerCase();
   }
+  if (/^#[0-9a-fA-F]{8}$/.test(t)) return t.slice(0, 7).toLowerCase();
   return null;
 }
 
-export default function ColorPickerInput({ label, value, onChange, optional, placeholder }: Props) {
-  const [text, setText] = useState(value);
-  const lastValidRef = useRef(value);
+export default function ColorPickerInput({
+  label,
+  value,
+  onChange,
+  optional,
+  placeholder,
+  allowAlpha,
+}: Props) {
+  const parsed = value ? splitHexAlpha(value) : { hex6: "", alpha: 1 };
+  const [text, setText] = useState(parsed.hex6);
+  const lastValidRef = useRef(parsed.hex6);
 
   useEffect(() => {
-    setText(value);
-    lastValidRef.current = value;
+    const p = value ? splitHexAlpha(value) : { hex6: "", alpha: 1 };
+    setText(p.hex6);
+    lastValidRef.current = p.hex6;
   }, [value]);
 
-  const hexValue = toHex(value) ?? "#121212";
+  const commit = (hex6: string, alpha: number) => {
+    const combined = allowAlpha ? combineHexAlpha(hex6, alpha) : hex6;
+    lastValidRef.current = hex6;
+    onChange(combined);
+  };
 
   const handleNativeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const hex = e.target.value;
-    lastValidRef.current = hex;
+    const hex = e.target.value.toLowerCase();
     setText(hex);
-    onChange(hex);
+    commit(hex, parsed.alpha);
   };
 
   const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -39,19 +62,30 @@ export default function ColorPickerInput({ label, value, onChange, optional, pla
   };
 
   const handleTextBlur = () => {
-    const hex = toHex(text.trim());
+    const hex = normalizeHex6(text);
     if (hex) {
-      lastValidRef.current = hex;
-      onChange(hex);
+      setText(hex);
+      commit(hex, parsed.alpha);
     } else {
       setText(lastValidRef.current);
     }
   };
 
-  const handleReset = () => {
+  const handleAlphaChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const pct = parseInt(e.target.value, 10);
+    if (Number.isNaN(pct)) return;
+    commit(parsed.hex6 || lastValidRef.current || "#121212", pct / 100);
+  };
+
+  const handleClear = () => {
     setText("");
     onChange("");
   };
+
+  const swatchColor = parsed.hex6
+    ? `rgba(${parseInt(parsed.hex6.slice(1, 3), 16)}, ${parseInt(parsed.hex6.slice(3, 5), 16)}, ${parseInt(parsed.hex6.slice(5, 7), 16)}, ${parsed.alpha})`
+    : "transparent";
+  const pickerHex = parsed.hex6 || "#121212";
 
   return (
     <div className="color-picker-row">
@@ -61,12 +95,12 @@ export default function ColorPickerInput({ label, value, onChange, optional, pla
           <input
             type="color"
             className="color-picker-native"
-            value={hexValue}
+            value={pickerHex}
             onChange={handleNativeChange}
           />
           <div
             className="color-picker-swatch"
-            style={{ background: value || "transparent" }}
+            style={{ background: swatchColor }}
           />
         </div>
         <input
@@ -78,8 +112,32 @@ export default function ColorPickerInput({ label, value, onChange, optional, pla
           onBlur={handleTextBlur}
           spellCheck={false}
         />
+        {allowAlpha && value && (
+          <div
+            className="color-picker-alpha"
+            title={`Opacity: ${Math.round(parsed.alpha * 100)}%`}
+          >
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={Math.round(parsed.alpha * 100)}
+              onChange={handleAlphaChange}
+              className="color-picker-alpha-range"
+              aria-label={`${label} opacity`}
+            />
+            <span className="color-picker-alpha-value">
+              {Math.round(parsed.alpha * 100)}%
+            </span>
+          </div>
+        )}
         {optional && value && (
-          <button className="color-picker-reset" onClick={handleReset} title="Reset to derived">
+          <button
+            className="color-picker-reset"
+            onClick={handleClear}
+            title="Reset to derived"
+          >
             ✕
           </button>
         )}

--- a/src/components/ColorPickerInput.tsx
+++ b/src/components/ColorPickerInput.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+  label: string;
+  value: string;
+  onChange: (hex: string) => void;
+  optional?: boolean;
+  placeholder?: string;
+}
+
+function toHex(color: string): string | null {
+  if (/^#[0-9a-fA-F]{6}$/.test(color)) return color;
+  if (/^#[0-9a-fA-F]{3}$/.test(color)) {
+    return "#" + color.slice(1).split("").map((c) => c + c).join("");
+  }
+  return null;
+}
+
+export default function ColorPickerInput({ label, value, onChange, optional, placeholder }: Props) {
+  const [text, setText] = useState(value);
+  const lastValidRef = useRef(value);
+
+  useEffect(() => {
+    setText(value);
+    lastValidRef.current = value;
+  }, [value]);
+
+  const hexValue = toHex(value) ?? "#121212";
+
+  const handleNativeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const hex = e.target.value;
+    lastValidRef.current = hex;
+    setText(hex);
+    onChange(hex);
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+  };
+
+  const handleTextBlur = () => {
+    const hex = toHex(text.trim());
+    if (hex) {
+      lastValidRef.current = hex;
+      onChange(hex);
+    } else {
+      setText(lastValidRef.current);
+    }
+  };
+
+  const handleReset = () => {
+    setText("");
+    onChange("");
+  };
+
+  return (
+    <div className="color-picker-row">
+      <span className="color-picker-label">{label}</span>
+      <div className="color-picker-controls">
+        <div className="color-picker-swatch-wrap">
+          <input
+            type="color"
+            className="color-picker-native"
+            value={hexValue}
+            onChange={handleNativeChange}
+          />
+          <div
+            className="color-picker-swatch"
+            style={{ background: value || "transparent" }}
+          />
+        </div>
+        <input
+          type="text"
+          className="color-picker-text"
+          value={text}
+          placeholder={placeholder ?? "#rrggbb"}
+          onChange={handleTextChange}
+          onBlur={handleTextBlur}
+          spellCheck={false}
+        />
+        {optional && value && (
+          <button className="color-picker-reset" onClick={handleReset} title="Reset to derived">
+            ✕
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CustomThemeEditor.css
+++ b/src/components/CustomThemeEditor.css
@@ -8,7 +8,26 @@
 
 .theme-mode-toggle {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.theme-reset-btn {
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-dim);
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-md);
+  padding: 0.25rem 0.625rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.theme-reset-btn:hover {
+  border-color: var(--accent-red);
+  color: var(--accent-red);
 }
 
 /* Color grid */
@@ -130,4 +149,281 @@
 
 .color-picker-reset:hover {
   color: var(--accent-red);
+}
+
+.kofi-picker {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.kofi-option {
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 0.125rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+  line-height: 0;
+}
+
+.kofi-option:hover {
+  border-color: var(--border-focus);
+}
+
+.kofi-option.active {
+  border-color: var(--accent-green);
+}
+
+.kofi-option.auto-active {
+  border-color: var(--border-focus);
+  opacity: 0.7;
+}
+
+.kofi-option--auto {
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.6875rem;
+  font-weight: var(--font-weight-md);
+  color: var(--text-muted);
+  padding: 0 0.375rem;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.kofi-option--auto.active {
+  border-color: var(--accent-green);
+  color: var(--text-primary);
+}
+
+.kofi-section-label {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 0.5rem;
+  margin-top: 0.125rem;
+}
+
+/* Alpha slider */
+.color-picker-alpha {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.color-picker-alpha-range {
+  width: 4.5rem;
+  height: 0.875rem;
+  cursor: pointer;
+  accent-color: var(--accent-green);
+}
+
+.color-picker-alpha-value {
+  font-family: 'DMSans', monospace;
+  font-size: 0.6875rem;
+  color: var(--text-dim);
+  min-width: 2.25rem;
+  text-align: right;
+}
+
+/* Invalid radius */
+.color-picker-text--invalid {
+  border-color: var(--accent-red);
+}
+
+/* Presets */
+.theme-presets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 0.5rem 0 0.25rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.theme-presets-label {
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.6875rem;
+  font-weight: var(--font-weight-md);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-dim);
+}
+
+.theme-presets-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.theme-preset-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-md);
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.theme-preset-btn:hover {
+  border-color: var(--border-focus);
+  color: var(--text-primary);
+}
+
+.theme-preset-btn--active {
+  border-color: var(--accent-green);
+  color: var(--text-primary);
+}
+
+.theme-preset-swatch {
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  flex-shrink: 0;
+}
+
+.theme-preset-name {
+  white-space: nowrap;
+}
+
+/* Contrast warning */
+.theme-contrast-warn {
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-md);
+  color: var(--accent-yellow);
+  background: color-mix(in oklab, var(--accent-yellow) 12%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent-yellow) 40%, transparent);
+  padding: 0.375rem 0.5rem;
+  border-radius: var(--radius-sm);
+}
+
+/* Import / Export */
+.theme-io {
+  display: flex;
+  gap: 0.375rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.theme-io-btn {
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-md);
+  padding: 0.3125rem 0.75rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.theme-io-btn:hover {
+  border-color: var(--border-focus);
+  color: var(--text-primary);
+}
+
+.theme-io-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.theme-io-btn--primary {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+.theme-io-btn--primary:hover:not(:disabled) {
+  border-color: var(--accent-green);
+  background: color-mix(in oklab, var(--accent-green) 15%, transparent);
+}
+
+.theme-import-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.theme-import-textarea {
+  font-family: 'DMSans', monospace;
+  font-size: 0.75rem;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem;
+  resize: vertical;
+  outline: none;
+  min-height: 4rem;
+}
+
+.theme-import-textarea:focus {
+  border-color: var(--border-focus);
+}
+
+.theme-import-error {
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.75rem;
+  color: var(--accent-red);
+}
+
+.theme-import-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.375rem;
+}
+
+/* Toast */
+.theme-toast {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.8125rem;
+  font-weight: var(--font-weight-md);
+  color: var(--text-primary);
+  box-shadow: var(--container-shadow);
+  animation: theme-toast-in 0.15s ease;
+}
+
+.theme-toast--info {
+  color: var(--text-muted);
+  justify-content: center;
+}
+
+.theme-toast-undo {
+  background: transparent;
+  border: none;
+  color: var(--accent-green);
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.8125rem;
+  font-weight: var(--font-weight-hv);
+  cursor: pointer;
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.theme-toast-undo:hover {
+  background: color-mix(in oklab, var(--accent-green) 15%, transparent);
+}
+
+@keyframes theme-toast-in {
+  from { opacity: 0; transform: translateY(0.25rem); }
+  to   { opacity: 1; transform: translateY(0); }
 }

--- a/src/components/CustomThemeEditor.css
+++ b/src/components/CustomThemeEditor.css
@@ -304,6 +304,45 @@
   border-radius: var(--radius-sm);
 }
 
+/* Background image */
+.bg-image-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+.bg-image-preview {
+  width: 4rem;
+  height: 4rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-subtle);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-color: var(--bg-input-off);
+  flex-shrink: 0;
+}
+
+.bg-image-preview--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-style: dashed;
+  color: var(--text-dim);
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.6875rem;
+  font-weight: var(--font-weight-md);
+  text-align: center;
+  padding: 0.25rem;
+}
+
+.bg-image-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  justify-content: center;
+}
+
 /* Import / Export */
 .theme-io {
   display: flex;
@@ -366,6 +405,21 @@
 
 .theme-import-textarea:focus {
   border-color: var(--border-focus);
+}
+
+.theme-import-textarea::-webkit-scrollbar {
+  width: 0.375rem;
+  background: var(--bg-elevated);
+  border-radius: 0.5rem;
+}
+
+.theme-import-textarea::-webkit-scrollbar-thumb {
+  background: var(--text-dim);
+  border-radius: 0.25rem;
+}
+
+.theme-import-textarea::-webkit-scrollbar-thumb:hover {
+  background: #777;
 }
 
 .theme-import-error {

--- a/src/components/CustomThemeEditor.css
+++ b/src/components/CustomThemeEditor.css
@@ -1,0 +1,133 @@
+.custom-theme-editor {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 0.75rem 0 0.5rem;
+}
+
+.theme-mode-toggle {
+  display: flex;
+  justify-content: flex-start;
+}
+
+/* Color grid */
+.color-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.color-group-label {
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.6875rem;
+  font-weight: var(--font-weight-md);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-dim);
+  padding-top: 0.5rem;
+  margin-top: 0.125rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.color-grid .color-group-label:first-child {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 0;
+}
+
+/* Row */
+.color-picker-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.color-picker-label {
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.8125rem;
+  font-weight: var(--font-weight-md);
+  color: var(--text-muted);
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.color-picker-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-shrink: 0;
+}
+
+/* Native color swatch */
+.color-picker-swatch-wrap {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.color-picker-native {
+  position: absolute;
+  inset: -0.5rem;
+  width: calc(100% + 1rem);
+  height: calc(100% + 1rem);
+  opacity: 0;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+}
+
+.color-picker-swatch {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* Hex text input */
+.color-picker-text {
+  font-family: 'DMSans', monospace;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-md);
+  width: 6rem;
+  padding: 0.25rem 0.5rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.color-picker-text:focus {
+  border-color: var(--border-focus);
+}
+
+.color-picker-text--full {
+  width: 9rem;
+}
+
+/* Reset button */
+.color-picker-reset {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 0.625rem;
+  padding: 0.1875rem 0.3125rem;
+  border-radius: var(--radius-sm);
+  line-height: 1;
+  transition: color 0.15s ease;
+}
+
+.color-picker-reset:hover {
+  color: var(--accent-red);
+}

--- a/src/components/CustomThemeEditor.tsx
+++ b/src/components/CustomThemeEditor.tsx
@@ -1,5 +1,5 @@
 import "./CustomThemeEditor.css";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { CustomThemeColors } from "../store";
 import { DEFAULT_SETTINGS } from "../store";
 import ColorPickerInput from "./ColorPickerInput";
@@ -9,16 +9,140 @@ import {
   validateRadius,
   sanitizeImportedTheme,
   fileToBackgroundDataUrl,
+  type KofiStyle,
 } from "../utils/theme";
+
+type EditorMode = "basic" | "advanced";
 
 interface Props {
   colors: CustomThemeColors;
-  mode: "basic" | "advanced";
+  mode: EditorMode;
   onColorsChange: (c: CustomThemeColors) => void;
-  onModeChange: (m: "basic" | "advanced") => void;
+  onModeChange: (m: EditorMode) => void;
 }
 
 const UNDO_MS = 6000;
+const TOAST_MS = 2500;
+const DEFAULT_BG_OPACITY = 30;
+const DEFAULT_BG_BLUR = 0;
+const DEFAULT_PANEL_OPACITY = 100;
+const MAX_BG_BLUR_PX = 10;
+
+const KOFI_STYLES: readonly KofiStyle[] = ["1", "2", "3", "4", "5", "6"];
+const KOFI_TITLES = ["Dark", "Yellow", "White", "Purple", "Blue", "Orange"];
+
+const BASIC_FIELDS = [
+  { key: "bgBase", label: "Background" },
+  { key: "textPrimary", label: "Text Color" },
+  { key: "accentGreen", label: "Green Accent" },
+  { key: "accentYellow", label: "Yellow Accent" },
+  { key: "accentRed", label: "Red Accent" },
+] as const satisfies ReadonlyArray<{ key: keyof CustomThemeColors; label: string }>;
+
+type AdvancedField =
+  | { kind: "required"; key: keyof CustomThemeColors; label: string }
+  | { kind: "optional"; key: keyof CustomThemeColors; label: string }
+  | { kind: "radius"; key: keyof CustomThemeColors; label: string; placeholder: string };
+
+interface AdvancedGroup {
+  title: string;
+  fields: AdvancedField[];
+}
+
+const ADVANCED_GROUPS: readonly AdvancedGroup[] = [
+  {
+    title: "Backgrounds",
+    fields: [
+      { kind: "required", key: "bgBase", label: "Base" },
+      { kind: "optional", key: "bgSurface", label: "Surface" },
+      { kind: "optional", key: "bgElevated", label: "Elevated" },
+      { kind: "optional", key: "bgInput", label: "Input" },
+      { kind: "optional", key: "bgInputOff", label: "Input Off" },
+    ],
+  },
+  {
+    title: "Borders",
+    fields: [
+      { kind: "optional", key: "border", label: "Border" },
+      { kind: "optional", key: "borderFocus", label: "Border Focus" },
+      { kind: "optional", key: "borderSubtle", label: "Border Subtle" },
+    ],
+  },
+  {
+    title: "Text",
+    fields: [
+      { kind: "required", key: "textPrimary", label: "Primary" },
+      { kind: "optional", key: "textMuted", label: "Muted" },
+      { kind: "optional", key: "textDim", label: "Dim" },
+    ],
+  },
+  {
+    title: "Accents",
+    fields: [
+      { kind: "required", key: "accentGreen", label: "Green" },
+      { kind: "required", key: "accentYellow", label: "Yellow" },
+      { kind: "required", key: "accentRed", label: "Red" },
+    ],
+  },
+  {
+    title: "Status",
+    fields: [
+      { kind: "optional", key: "statusSuccess", label: "Success" },
+      { kind: "optional", key: "statusError", label: "Error" },
+    ],
+  },
+  {
+    title: "Radius",
+    fields: [
+      { kind: "radius", key: "radiusSm", label: "Small", placeholder: "0.375rem" },
+      { kind: "radius", key: "radiusMd", label: "Medium", placeholder: "0.625rem" },
+      { kind: "radius", key: "radiusLg", label: "Large", placeholder: "0.875rem" },
+    ],
+  },
+];
+
+function useToast() {
+  const [toast, setToast] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const show = useCallback((msg: string, ms = TOAST_MS) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setToast(msg);
+    timerRef.current = setTimeout(() => setToast(null), ms);
+  }, []);
+
+  return { toast, show };
+}
+
+function useUndoSnapshot<T>() {
+  const [snapshot, setSnapshot] = useState<T | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const capture = useCallback((value: T) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setSnapshot(value);
+    timerRef.current = setTimeout(() => setSnapshot(null), UNDO_MS);
+  }, []);
+
+  const clear = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setSnapshot(null);
+  }, []);
+
+  return { snapshot, capture, clear };
+}
 
 interface RadiusInputProps {
   label: string;
@@ -30,17 +154,29 @@ interface RadiusInputProps {
 function RadiusInput({ label, value, placeholder, onCommit }: RadiusInputProps) {
   const [text, setText] = useState(value);
   const [invalid, setInvalid] = useState(false);
+
   useEffect(() => {
     setText(value);
     setInvalid(false);
   }, [value]);
+
+  const handleBlur = () => {
+    if (validateRadius(text)) {
+      setInvalid(false);
+      onCommit(text);
+    } else {
+      setInvalid(true);
+    }
+  };
 
   return (
     <div className="color-picker-row">
       <span className="color-picker-label">{label}</span>
       <input
         type="text"
-        className={`color-picker-text color-picker-text--full ${invalid ? "color-picker-text--invalid" : ""}`}
+        className={`color-picker-text color-picker-text--full ${
+          invalid ? "color-picker-text--invalid" : ""
+        }`}
         value={text}
         placeholder={placeholder}
         spellCheck={false}
@@ -48,16 +184,502 @@ function RadiusInput({ label, value, placeholder, onCommit }: RadiusInputProps) 
           setText(e.target.value);
           if (invalid) setInvalid(false);
         }}
-        onBlur={() => {
-          if (validateRadius(text)) {
-            setInvalid(false);
-            onCommit(text);
-          } else {
-            setInvalid(true);
-          }
-        }}
+        onBlur={handleBlur}
       />
     </div>
+  );
+}
+
+interface SliderRowProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  format: (v: number) => string;
+  onChange: (v: number) => void;
+}
+
+function SliderRow({ label, value, min, max, step, format, onChange }: SliderRowProps) {
+  return (
+    <div className="color-picker-row">
+      <span className="color-picker-label">{label}</span>
+      <div className="color-picker-alpha">
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          onChange={(e) => onChange(parseFloat(e.target.value))}
+          className="color-picker-alpha-range"
+        />
+        <span className="color-picker-alpha-value">{format(value)}</span>
+      </div>
+    </div>
+  );
+}
+
+interface ModeToggleProps {
+  mode: EditorMode;
+  onChange: (m: EditorMode) => void;
+  onReset: () => void;
+}
+
+function ModeToggle({ mode, onChange, onReset }: ModeToggleProps) {
+  return (
+    <div className="theme-mode-toggle">
+      <div className="settings-seg-group">
+        {(["basic", "advanced"] as const).map((m) => (
+          <button
+            key={m}
+            className={`settings-seg-btn ${mode === m ? "active" : ""}`}
+            onClick={() => onChange(m)}
+          >
+            {m === "basic" ? "Basic" : "Advanced"}
+          </button>
+        ))}
+      </div>
+      <button className="theme-reset-btn" onClick={onReset} title="Reset to defaults">
+        Reset
+      </button>
+    </div>
+  );
+}
+
+interface PresetGridProps {
+  active: (preset: CustomThemeColors) => boolean;
+  onPick: (preset: CustomThemeColors) => void;
+}
+
+function PresetGrid({ active, onPick }: PresetGridProps) {
+  return (
+    <div className="theme-presets">
+      <span className="theme-presets-label">Presets</span>
+      <div className="theme-presets-grid">
+        {THEME_PRESETS.map((preset) => (
+          <button
+            key={preset.name}
+            className={`theme-preset-btn${
+              active(preset.colors) ? " theme-preset-btn--active" : ""
+            }`}
+            onClick={() => onPick(preset.colors)}
+            title={`Apply ${preset.name}`}
+          >
+            <span
+              className="theme-preset-swatch"
+              style={{
+                background: `linear-gradient(135deg, ${preset.colors.bgBase} 0 50%, ${preset.colors.accentGreen} 50% 100%)`,
+                borderColor: preset.colors.textPrimary,
+              }}
+            />
+            <span className="theme-preset-name">{preset.name}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface BasicEditorProps {
+  colors: CustomThemeColors;
+  onPatch: (patch: Partial<CustomThemeColors>) => void;
+}
+
+function BasicEditor({ colors, onPatch }: BasicEditorProps) {
+  return (
+    <div className="color-grid">
+      {BASIC_FIELDS.map(({ key, label }) => (
+        <ColorPickerInput
+          key={key}
+          label={label}
+          value={(colors[key] as string) ?? ""}
+          onChange={(v) => onPatch({ [key]: v })}
+          allowAlpha
+        />
+      ))}
+    </div>
+  );
+}
+
+interface AdvancedEditorProps {
+  colors: CustomThemeColors;
+  onPatch: (patch: Partial<CustomThemeColors>) => void;
+  onSetOptional: (key: keyof CustomThemeColors, value: string) => void;
+}
+
+function AdvancedEditor({ colors, onPatch, onSetOptional }: AdvancedEditorProps) {
+  return (
+    <div className="color-grid color-grid--advanced">
+      {ADVANCED_GROUPS.map((group) => (
+        <GroupSection
+          key={group.title}
+          group={group}
+          colors={colors}
+          onPatch={onPatch}
+          onSetOptional={onSetOptional}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface GroupSectionProps {
+  group: AdvancedGroup;
+  colors: CustomThemeColors;
+  onPatch: (patch: Partial<CustomThemeColors>) => void;
+  onSetOptional: (key: keyof CustomThemeColors, value: string) => void;
+}
+
+function GroupSection({ group, colors, onPatch, onSetOptional }: GroupSectionProps) {
+  return (
+    <>
+      <div className="color-group-label">{group.title}</div>
+      {group.fields.map((field) => {
+        const current = (colors[field.key] as string | undefined) ?? "";
+        if (field.kind === "required") {
+          return (
+            <ColorPickerInput
+              key={field.key}
+              label={field.label}
+              value={current}
+              onChange={(v) => onPatch({ [field.key]: v })}
+              allowAlpha
+            />
+          );
+        }
+        if (field.kind === "optional") {
+          return (
+            <ColorPickerInput
+              key={field.key}
+              label={field.label}
+              value={current}
+              onChange={(v) => onSetOptional(field.key, v)}
+              optional
+              placeholder="auto"
+              allowAlpha
+            />
+          );
+        }
+        return (
+          <RadiusInput
+            key={field.key}
+            label={field.label}
+            value={current}
+            placeholder={field.placeholder}
+            onCommit={(v) => onSetOptional(field.key, v)}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+interface BackgroundSectionProps {
+  colors: CustomThemeColors;
+  onColorsChange: (c: CustomThemeColors) => void;
+  showToast: (msg: string) => void;
+}
+
+function BackgroundSection({ colors, onColorsChange, showToast }: BackgroundSectionProps) {
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const [busy, setBusy] = useState(false);
+  const hasImage = Boolean(colors.backgroundImage);
+
+  const pickImage = async (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      showToast("Only image files are supported");
+      return;
+    }
+    setBusy(true);
+    try {
+      const dataUrl = await fileToBackgroundDataUrl(file);
+      onColorsChange({
+        ...colors,
+        backgroundImage: dataUrl,
+        backgroundOpacity: colors.backgroundOpacity ?? DEFAULT_BG_OPACITY,
+        backgroundBlur: colors.backgroundBlur ?? DEFAULT_BG_BLUR,
+      });
+      showToast("Background image saved");
+    } catch (err) {
+      console.error("Failed to load image:", err);
+      showToast("Failed to load image");
+    } finally {
+      setBusy(false);
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  };
+
+  const removeImage = () => {
+    const next = { ...colors };
+    delete next.backgroundImage;
+    delete next.backgroundOpacity;
+    delete next.backgroundBlur;
+    onColorsChange(next);
+  };
+
+  return (
+    <>
+      <div className="color-group-label kofi-section-label">Background Image</div>
+      <div className="bg-image-row">
+        {hasImage ? (
+          <div
+            className="bg-image-preview"
+            style={{ backgroundImage: `url("${colors.backgroundImage}")` }}
+          />
+        ) : (
+          <div className="bg-image-preview bg-image-preview--empty">No image</div>
+        )}
+        <div className="bg-image-actions">
+          <button
+            className="theme-io-btn"
+            onClick={() => fileRef.current?.click()}
+            disabled={busy}
+          >
+            {hasImage ? "Change" : "Select image"}
+          </button>
+          {hasImage && (
+            <button className="theme-io-btn" onClick={removeImage} disabled={busy}>
+              Remove
+            </button>
+          )}
+        </div>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          style={{ display: "none" }}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) void pickImage(file);
+          }}
+        />
+      </div>
+
+      {hasImage && (
+        <>
+          <SliderRow
+            label="Opacity"
+            value={colors.backgroundOpacity ?? DEFAULT_BG_OPACITY}
+            min={0}
+            max={100}
+            step={1}
+            format={(v) => `${Math.round(v)}%`}
+            onChange={(v) =>
+              onColorsChange({ ...colors, backgroundOpacity: Math.round(v) })
+            }
+          />
+          <SliderRow
+            label="Blur"
+            value={colors.backgroundBlur ?? DEFAULT_BG_BLUR}
+            min={0}
+            max={MAX_BG_BLUR_PX}
+            step={0.1}
+            format={(v) => `${v.toFixed(1)}px`}
+            onChange={(v) => onColorsChange({ ...colors, backgroundBlur: v })}
+          />
+        </>
+      )}
+
+      <SliderRow
+        label="Panel opacity"
+        value={colors.panelOpacity ?? DEFAULT_PANEL_OPACITY}
+        min={0}
+        max={100}
+        step={1}
+        format={(v) => `${Math.round(v)}%`}
+        onChange={(v) => onColorsChange({ ...colors, panelOpacity: Math.round(v) })}
+      />
+    </>
+  );
+}
+
+interface KofiSectionProps {
+  colors: CustomThemeColors;
+  onColorsChange: (c: CustomThemeColors) => void;
+}
+
+function KofiSection({ colors, onColorsChange }: KofiSectionProps) {
+  const effective = colors.kofiStyle ?? getAutoKofiStyle(colors.bgBase);
+
+  const pickAuto = () => {
+    const next = { ...colors };
+    delete next.kofiStyle;
+    onColorsChange(next);
+  };
+
+  const getClass = (style: KofiStyle) => {
+    if (colors.kofiStyle === style) return "kofi-option active";
+    if (!colors.kofiStyle && effective === style) return "kofi-option auto-active";
+    return "kofi-option";
+  };
+
+  return (
+    <>
+      <div className="color-group-label kofi-section-label">Ko-fi Button</div>
+      <div className="color-picker-row">
+        <span className="color-picker-label">Style</span>
+        <div className="kofi-picker">
+          <button
+            className={`kofi-option kofi-option--auto ${!colors.kofiStyle ? "active" : ""}`}
+            onClick={pickAuto}
+            title="Auto"
+          >
+            Auto
+          </button>
+          {KOFI_STYLES.map((style, idx) => (
+            <button
+              key={style}
+              className={getClass(style)}
+              onClick={() => onColorsChange({ ...colors, kofiStyle: style })}
+              title={KOFI_TITLES[idx]}
+            >
+              <img
+                src={`https://storage.ko-fi.com/cdn/kofi${style}.png?v=6`}
+                alt={`kofi${style}`}
+                height="20"
+              />
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+interface ImportExportProps {
+  colors: CustomThemeColors;
+  onImport: (next: CustomThemeColors) => void;
+  showToast: (msg: string) => void;
+}
+
+function ImportExport({ colors, onImport, showToast }: ImportExportProps) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const copyTheme = async () => {
+    // Strip image fields — DataURLs are per-device and can be megabytes.
+    // Recipients can set their own background image after importing.
+    const { backgroundImage: _bg, backgroundOpacity: _op, backgroundBlur: _bl, ...exportable } = colors;
+    const json = JSON.stringify(exportable, null, 2);
+    try {
+      await navigator.clipboard.writeText(json);
+      showToast("Copied theme to clipboard");
+    } catch {
+      showToast("Copy failed — clipboard unavailable");
+    }
+  };
+
+  const downloadTheme = () => {
+    // Download includes EVERYTHING (even the background image DataURL).
+    const json = JSON.stringify(colors, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `blur-theme-${Date.now()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    showToast("Theme downloaded (Saved to Downloads folder)");
+  };
+
+  const applyImport = () => {
+    setError(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      setError("Invalid JSON");
+      return;
+    }
+    const sanitized = sanitizeImportedTheme(parsed);
+    if (!sanitized) {
+      setError("Missing required colors");
+      return;
+    }
+    onImport(sanitized);
+    setText("");
+    setOpen(false);
+    showToast("Theme imported");
+  };
+
+  const pasteFromClipboard = async () => {
+    try {
+      setText(await navigator.clipboard.readText());
+      setError(null);
+    } catch {
+      setError("Clipboard unavailable — paste manually");
+    }
+  };
+
+  return (
+    <>
+      <div className="theme-io">
+        <button
+          className="theme-io-btn"
+          onClick={copyTheme}
+          title="Copy theme colors to clipboard (No image)"
+        >
+          Copy
+        </button>
+        <button
+          className="theme-io-btn"
+          onClick={downloadTheme}
+          title="Download full theme as file (Includes image)"
+        >
+          Download
+        </button>
+        <button
+          className="theme-io-btn"
+          onClick={() => {
+            setOpen((prev) => !prev);
+            setError(null);
+          }}
+        >
+          {open ? "Cancel" : "Import"}
+        </button>
+      </div>
+
+      {open && (
+        <div className="theme-import-panel">
+          <textarea
+            className="theme-import-textarea"
+            placeholder="Paste theme JSON here…"
+            value={text}
+            onChange={(e) => {
+              setText(e.target.value);
+              if (error) setError(null);
+            }}
+            spellCheck={false}
+            rows={4}
+          />
+          {error && <div className="theme-import-error">{error}</div>}
+          <div className="theme-import-actions">
+            <button className="theme-io-btn" onClick={pasteFromClipboard}>
+              From clipboard
+            </button>
+            <button
+              className="theme-io-btn theme-io-btn--primary"
+              onClick={applyImport}
+              disabled={!text.trim()}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function isSamePreset(a: CustomThemeColors, b: CustomThemeColors): boolean {
+  return (
+    a.bgBase === b.bgBase &&
+    a.textPrimary === b.textPrimary &&
+    a.accentGreen === b.accentGreen &&
+    a.accentYellow === b.accentYellow &&
+    a.accentRed === b.accentRed
   );
 }
 
@@ -67,450 +689,89 @@ export default function CustomThemeEditor({
   onColorsChange,
   onModeChange,
 }: Props) {
-  const [undoSnap, setUndoSnap] = useState<CustomThemeColors | null>(null);
-  const [toast, setToast] = useState<string | null>(null);
-  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [showImport, setShowImport] = useState(false);
-  const [importText, setImportText] = useState("");
-  const [importError, setImportError] = useState<string | null>(null);
-  const bgFileRef = useRef<HTMLInputElement | null>(null);
-  const [bgBusy, setBgBusy] = useState(false);
+  const { toast, show: showToast } = useToast();
+  const { snapshot: undoSnap, capture: captureUndo, clear: clearUndo } =
+    useUndoSnapshot<CustomThemeColors>();
 
-  const handleBgPick = async (file: File) => {
-    if (!file.type.startsWith("image/")) {
-      showToast("Only image files are supported");
-      return;
-    }
-    setBgBusy(true);
-    try {
-      const dataUrl = await fileToBackgroundDataUrl(file);
-      onColorsChange({
-        ...colors,
-        backgroundImage: dataUrl,
-        backgroundOpacity: colors.backgroundOpacity ?? 30,
-        backgroundBlur: colors.backgroundBlur ?? 0,
-      });
-      showToast("Background image saved");
-    } catch (err) {
-      console.error("Failed to load image:", err);
-      showToast("Failed to load image");
-    } finally {
-      setBgBusy(false);
-      if (bgFileRef.current) bgFileRef.current.value = "";
-    }
-  };
+  const patch = useCallback(
+    (changes: Partial<CustomThemeColors>) => {
+      onColorsChange({ ...colors, ...changes });
+    },
+    [colors, onColorsChange],
+  );
 
-  const handleBgRemove = () => {
-    const { backgroundImage: _img, backgroundOpacity: _o, backgroundBlur: _b, ...rest } = colors;
-    onColorsChange(rest as CustomThemeColors);
-  };
-
-  useEffect(() => {
-    return () => {
-      if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
-      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    };
-  }, []);
-
-  const showToast = (msg: string, ms = 2500) => {
-    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    setToast(msg);
-    toastTimerRef.current = setTimeout(() => setToast(null), ms);
-  };
-
-  const startUndo = (snapshot: CustomThemeColors) => {
-    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
-    setUndoSnap(snapshot);
-    undoTimerRef.current = setTimeout(() => setUndoSnap(null), UNDO_MS);
-  };
-
-  const set = (key: keyof CustomThemeColors, value: string) => {
-    onColorsChange({ ...colors, [key]: value || undefined });
-  };
+  const setOptional = useCallback(
+    (key: keyof CustomThemeColors, value: string) => {
+      onColorsChange({ ...colors, [key]: value || undefined });
+    },
+    [colors, onColorsChange],
+  );
 
   const handleReset = () => {
-    startUndo(colors);
+    captureUndo(colors);
     onColorsChange(DEFAULT_SETTINGS.customTheme);
+  };
+
+  const handlePreset = (preset: CustomThemeColors) => {
+    captureUndo(colors);
+    onColorsChange({ ...preset });
+  };
+
+  const handleImport = (next: CustomThemeColors) => {
+    captureUndo(colors);
+    onColorsChange(next);
   };
 
   const handleUndo = () => {
     if (!undoSnap) return;
     onColorsChange(undoSnap);
-    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
-    setUndoSnap(null);
+    clearUndo();
   };
-
-  const isPresetActive = (presetColors: CustomThemeColors) =>
-    colors.bgBase === presetColors.bgBase &&
-    colors.textPrimary === presetColors.textPrimary &&
-    colors.accentGreen === presetColors.accentGreen &&
-    colors.accentYellow === presetColors.accentYellow &&
-    colors.accentRed === presetColors.accentRed;
-
-  const handlePreset = (presetColors: CustomThemeColors) => {
-    startUndo(colors);
-    onColorsChange({ ...presetColors });
-  };
-
-  const handleExport = async () => {
-    const json = JSON.stringify(colors, null, 2);
-    try {
-      await navigator.clipboard.writeText(json);
-      showToast("Copied theme to clipboard");
-    } catch {
-      showToast("Copy failed — clipboard unavailable");
-    }
-  };
-
-  const handleImportApply = () => {
-    setImportError(null);
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(importText);
-    } catch {
-      setImportError("Invalid JSON");
-      return;
-    }
-    const sanitized = sanitizeImportedTheme(parsed);
-    if (!sanitized) {
-      setImportError("Missing required colors");
-      return;
-    }
-    startUndo(colors);
-    onColorsChange(sanitized);
-    setImportText("");
-    setShowImport(false);
-    showToast("Theme imported");
-  };
-
-  const handleImportFromClipboard = async () => {
-    try {
-      const txt = await navigator.clipboard.readText();
-      setImportText(txt);
-      setImportError(null);
-    } catch {
-      setImportError("Clipboard unavailable — paste manually");
-    }
-  };
-
-  const effectiveKofiStyle = colors.kofiStyle ?? getAutoKofiStyle(colors.bgBase);
 
   return (
     <div className="custom-theme-editor">
-      <div className="theme-mode-toggle">
-        <div className="settings-seg-group">
-          {(["basic", "advanced"] as const).map((m) => (
-            <button
-              key={m}
-              className={`settings-seg-btn ${mode === m ? "active" : ""}`}
-              onClick={() => onModeChange(m)}
-            >
-              {m === "basic" ? "Basic" : "Advanced"}
-            </button>
-          ))}
-        </div>
-        <button
-          className="theme-reset-btn"
-          onClick={handleReset}
-          title="Reset to defaults"
-        >
-          Reset
-        </button>
-      </div>
+      <ModeToggle mode={mode} onChange={onModeChange} onReset={handleReset} />
 
-      <div className="theme-presets">
-        <span className="theme-presets-label">Presets</span>
-        <div className="theme-presets-grid">
-          {THEME_PRESETS.map((p) => (
-            <button
-              key={p.name}
-              className={`theme-preset-btn${isPresetActive(p.colors) ? " theme-preset-btn--active" : ""}`}
-              onClick={() => handlePreset(p.colors)}
-              title={`Apply ${p.name}`}
-            >
-              <span
-                className="theme-preset-swatch"
-                style={{
-                  background: `linear-gradient(135deg, ${p.colors.bgBase} 0 50%, ${p.colors.accentGreen} 50% 100%)`,
-                  borderColor: p.colors.textPrimary,
-                }}
-              />
-              <span className="theme-preset-name">{p.name}</span>
-            </button>
-          ))}
-        </div>
-      </div>
+      <PresetGrid
+        active={(preset) => isSamePreset(colors, preset)}
+        onPick={handlePreset}
+      />
 
       {mode === "basic" ? (
-        <div className="color-grid">
-          <ColorPickerInput
-            label="Background"
-            value={colors.bgBase}
-            onChange={(v) => onColorsChange({ ...colors, bgBase: v })}
-            allowAlpha
-          />
-          <ColorPickerInput
-            label="Text Color"
-            value={colors.textPrimary}
-            onChange={(v) => onColorsChange({ ...colors, textPrimary: v })}
-            allowAlpha
-          />
-          <ColorPickerInput
-            label="Green Accent"
-            value={colors.accentGreen}
-            onChange={(v) => onColorsChange({ ...colors, accentGreen: v })}
-            allowAlpha
-          />
-          <ColorPickerInput
-            label="Yellow Accent"
-            value={colors.accentYellow}
-            onChange={(v) => onColorsChange({ ...colors, accentYellow: v })}
-            allowAlpha
-          />
-          <ColorPickerInput
-            label="Red Accent"
-            value={colors.accentRed}
-            onChange={(v) => onColorsChange({ ...colors, accentRed: v })}
-            allowAlpha
-          />
-        </div>
+        <BasicEditor colors={colors} onPatch={patch} />
       ) : (
-        <div className="color-grid color-grid--advanced">
-          <div className="color-group-label">Backgrounds</div>
-          <ColorPickerInput label="Base" value={colors.bgBase} onChange={(v) => onColorsChange({ ...colors, bgBase: v })} allowAlpha />
-          <ColorPickerInput label="Surface" value={colors.bgSurface ?? ""} onChange={(v) => set("bgSurface", v)} optional placeholder="auto" allowAlpha />
-          <ColorPickerInput label="Elevated" value={colors.bgElevated ?? ""} onChange={(v) => set("bgElevated", v)} optional placeholder="auto" allowAlpha />
-          <ColorPickerInput label="Input" value={colors.bgInput ?? ""} onChange={(v) => set("bgInput", v)} optional placeholder="auto" allowAlpha />
-          <ColorPickerInput label="Input Off" value={colors.bgInputOff ?? ""} onChange={(v) => set("bgInputOff", v)} optional placeholder="auto" allowAlpha />
-
-          <div className="color-group-label">Borders</div>
-          <ColorPickerInput label="Border" value={colors.border ?? ""} onChange={(v) => set("border", v)} optional placeholder="auto" allowAlpha />
-          <ColorPickerInput label="Border Focus" value={colors.borderFocus ?? ""} onChange={(v) => set("borderFocus", v)} optional placeholder="auto" allowAlpha />
-          <ColorPickerInput label="Border Subtle" value={colors.borderSubtle ?? ""} onChange={(v) => set("borderSubtle", v)} optional placeholder="auto" allowAlpha />
-
-          <div className="color-group-label">Text</div>
-          <ColorPickerInput label="Primary" value={colors.textPrimary} onChange={(v) => onColorsChange({ ...colors, textPrimary: v })} allowAlpha />
-          <ColorPickerInput label="Muted" value={colors.textMuted ?? ""} onChange={(v) => set("textMuted", v)} optional placeholder="auto" allowAlpha />
-          <ColorPickerInput label="Dim" value={colors.textDim ?? ""} onChange={(v) => set("textDim", v)} optional placeholder="auto" allowAlpha />
-
-          <div className="color-group-label">Accents</div>
-          <ColorPickerInput label="Green" value={colors.accentGreen} onChange={(v) => onColorsChange({ ...colors, accentGreen: v })} allowAlpha />
-          <ColorPickerInput label="Yellow" value={colors.accentYellow} onChange={(v) => onColorsChange({ ...colors, accentYellow: v })} allowAlpha />
-          <ColorPickerInput label="Red" value={colors.accentRed} onChange={(v) => onColorsChange({ ...colors, accentRed: v })} allowAlpha />
-
-          <div className="color-group-label">Status</div>
-          <ColorPickerInput label="Success" value={colors.statusSuccess ?? ""} onChange={(v) => set("statusSuccess", v)} optional placeholder="auto" allowAlpha />
-          <ColorPickerInput label="Error" value={colors.statusError ?? ""} onChange={(v) => set("statusError", v)} optional placeholder="auto" allowAlpha />
-
-          <div className="color-group-label">Radius</div>
-          <RadiusInput label="Small" value={colors.radiusSm ?? ""} placeholder="0.375rem" onCommit={(v) => set("radiusSm", v)} />
-          <RadiusInput label="Medium" value={colors.radiusMd ?? ""} placeholder="0.625rem" onCommit={(v) => set("radiusMd", v)} />
-          <RadiusInput label="Large" value={colors.radiusLg ?? ""} placeholder="0.875rem" onCommit={(v) => set("radiusLg", v)} />
-        </div>
+        <AdvancedEditor
+          colors={colors}
+          onPatch={patch}
+          onSetOptional={setOptional}
+        />
       )}
 
       <div className="color-grid">
-        <div className="color-group-label kofi-section-label">Background Image</div>
-        <div className="bg-image-row">
-          {colors.backgroundImage ? (
-            <div
-              className="bg-image-preview"
-              style={{ backgroundImage: `url("${colors.backgroundImage}")` }}
-            />
-          ) : (
-            <div className="bg-image-preview bg-image-preview--empty">No image</div>
-          )}
-          <div className="bg-image-actions">
-            <button
-              className="theme-io-btn"
-              onClick={() => bgFileRef.current?.click()}
-              disabled={bgBusy}
-            >
-              {colors.backgroundImage ? "Change" : "Select image"}
-            </button>
-            {colors.backgroundImage && (
-              <button
-                className="theme-io-btn"
-                onClick={handleBgRemove}
-                disabled={bgBusy}
-              >
-                Remove
-              </button>
-            )}
-          </div>
-          <input
-            ref={bgFileRef}
-            type="file"
-            accept="image/*"
-            style={{ display: "none" }}
-            onChange={(e) => {
-              const file = e.target.files?.[0];
-              if (file) void handleBgPick(file);
-            }}
-          />
-        </div>
-        {colors.backgroundImage && (
-          <>
-            <div className="color-picker-row">
-              <span className="color-picker-label">Opacity</span>
-              <div className="color-picker-alpha">
-                <input
-                  type="range"
-                  min={0}
-                  max={100}
-                  step={1}
-                  value={colors.backgroundOpacity ?? 30}
-                  onChange={(e) =>
-                    onColorsChange({
-                      ...colors,
-                      backgroundOpacity: parseInt(e.target.value, 10),
-                    })
-                  }
-                  className="color-picker-alpha-range"
-                />
-                <span className="color-picker-alpha-value">
-                  {colors.backgroundOpacity ?? 30}%
-                </span>
-              </div>
-            </div>
-            <div className="color-picker-row">
-              <span className="color-picker-label">Blur</span>
-              <div className="color-picker-alpha">
-                <input
-                  type="range"
-                  min={0}
-                  max={10}
-                  step={0.1}
-                  value={colors.backgroundBlur ?? 0}
-                  onChange={(e) =>
-                    onColorsChange({
-                      ...colors,
-                      backgroundBlur: parseFloat(e.target.value),
-                    })
-                  }
-                  className="color-picker-alpha-range"
-                />
-                <span className="color-picker-alpha-value">
-                  {(colors.backgroundBlur ?? 0).toFixed(1)}px
-                </span>
-              </div>
-            </div>
-          </>
-        )}
-        <div className="color-picker-row">
-          <span className="color-picker-label">Panel opacity</span>
-          <div className="color-picker-alpha">
-            <input
-              type="range"
-              min={0}
-              max={100}
-              step={1}
-              value={colors.panelOpacity ?? 100}
-              onChange={(e) =>
-                onColorsChange({
-                  ...colors,
-                  panelOpacity: parseInt(e.target.value, 10),
-                })
-              }
-              className="color-picker-alpha-range"
-            />
-            <span className="color-picker-alpha-value">
-              {colors.panelOpacity ?? 100}%
-            </span>
-          </div>
-        </div>
-        <div className="color-group-label kofi-section-label">Ko-fi Button</div>
-        <div className="color-picker-row">
-          <span className="color-picker-label">Style</span>
-          <div className="kofi-picker">
-            <button
-              className={`kofi-option kofi-option--auto ${!colors.kofiStyle ? "active" : ""}`}
-              onClick={() => {
-                const { kofiStyle: _k, ...rest } = colors;
-                onColorsChange(rest as CustomThemeColors);
-              }}
-              title="Auto"
-            >
-              Auto
-            </button>
-            {(["1", "2", "3", "4", "5", "6"] as const).map((n) => (
-              <button
-                key={n}
-                className={`kofi-option ${
-                  colors.kofiStyle === n
-                    ? "active"
-                    : !colors.kofiStyle && effectiveKofiStyle === n
-                    ? "auto-active"
-                    : ""
-                }`}
-                onClick={() => onColorsChange({ ...colors, kofiStyle: n })}
-                title={["Dark", "Yellow", "White", "Purple", "Blue", "Orange"][+n - 1]}
-              >
-                <img
-                  src={`https://storage.ko-fi.com/cdn/kofi${n}.png?v=6`}
-                  alt={`kofi${n}`}
-                  height="20"
-                />
-              </button>
-            ))}
-          </div>
-        </div>
+        <BackgroundSection
+          colors={colors}
+          onColorsChange={onColorsChange}
+          showToast={showToast}
+        />
+        <KofiSection colors={colors} onColorsChange={onColorsChange} />
       </div>
 
-      <div className="theme-io">
-        <button className="theme-io-btn" onClick={handleExport} title="Copy theme JSON to clipboard">
-          Export
-        </button>
-        <button
-          className="theme-io-btn"
-          onClick={() => {
-            setShowImport((s) => !s);
-            setImportError(null);
-          }}
-        >
-          {showImport ? "Cancel" : "Import"}
-        </button>
-      </div>
+      <ImportExport
+        colors={colors}
+        onImport={handleImport}
+        showToast={showToast}
+      />
 
-      {showImport && (
-        <div className="theme-import-panel">
-          <textarea
-            className="theme-import-textarea"
-            placeholder="Paste theme JSON here…"
-            value={importText}
-            onChange={(e) => {
-              setImportText(e.target.value);
-              if (importError) setImportError(null);
-            }}
-            spellCheck={false}
-            rows={4}
-          />
-          {importError && <div className="theme-import-error">{importError}</div>}
-          <div className="theme-import-actions">
-            <button className="theme-io-btn" onClick={handleImportFromClipboard}>
-              From clipboard
-            </button>
-            <button
-              className="theme-io-btn theme-io-btn--primary"
-              onClick={handleImportApply}
-              disabled={!importText.trim()}
-            >
-              Apply
-            </button>
-          </div>
-        </div>
-      )}
-
-      {undoSnap && (
+      {undoSnap ? (
         <div className="theme-toast">
           <span>Theme changed</span>
           <button className="theme-toast-undo" onClick={handleUndo}>
             Undo
           </button>
         </div>
+      ) : (
+        toast && <div className="theme-toast theme-toast--info">{toast}</div>
       )}
-      {!undoSnap && toast && <div className="theme-toast theme-toast--info">{toast}</div>}
     </div>
   );
 }

--- a/src/components/CustomThemeEditor.tsx
+++ b/src/components/CustomThemeEditor.tsx
@@ -1,0 +1,124 @@
+import "./CustomThemeEditor.css";
+import type { CustomThemeColors } from "../store";
+import ColorPickerInput from "./ColorPickerInput";
+
+interface Props {
+  colors: CustomThemeColors;
+  mode: "basic" | "advanced";
+  onColorsChange: (c: CustomThemeColors) => void;
+  onModeChange: (m: "basic" | "advanced") => void;
+}
+
+export default function CustomThemeEditor({ colors, mode, onColorsChange, onModeChange }: Props) {
+  const set = (key: keyof CustomThemeColors, value: string) => {
+    onColorsChange({ ...colors, [key]: value || undefined });
+  };
+
+  return (
+    <div className="custom-theme-editor">
+      <div className="theme-mode-toggle">
+        <div className="settings-seg-group">
+          {(["basic", "advanced"] as const).map((m) => (
+            <button
+              key={m}
+              className={`settings-seg-btn ${mode === m ? "active" : ""}`}
+              onClick={() => onModeChange(m)}
+            >
+              {m === "basic" ? "Basic" : "Advanced"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {mode === "basic" ? (
+        <div className="color-grid">
+          <ColorPickerInput
+            label="Background"
+            value={colors.bgBase}
+            onChange={(v) => onColorsChange({ ...colors, bgBase: v })}
+          />
+          <ColorPickerInput
+            label="Text Color"
+            value={colors.textPrimary}
+            onChange={(v) => onColorsChange({ ...colors, textPrimary: v })}
+          />
+          <ColorPickerInput
+            label="Green Accent"
+            value={colors.accentGreen}
+            onChange={(v) => onColorsChange({ ...colors, accentGreen: v })}
+          />
+          <ColorPickerInput
+            label="Yellow Accent"
+            value={colors.accentYellow}
+            onChange={(v) => onColorsChange({ ...colors, accentYellow: v })}
+          />
+          <ColorPickerInput
+            label="Red Accent"
+            value={colors.accentRed}
+            onChange={(v) => onColorsChange({ ...colors, accentRed: v })}
+          />
+        </div>
+      ) : (
+        <div className="color-grid color-grid--advanced">
+          <div className="color-group-label">Backgrounds</div>
+          <ColorPickerInput label="Base" value={colors.bgBase} onChange={(v) => onColorsChange({ ...colors, bgBase: v })} />
+          <ColorPickerInput label="Surface" value={colors.bgSurface ?? ""} onChange={(v) => set("bgSurface", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Elevated" value={colors.bgElevated ?? ""} onChange={(v) => set("bgElevated", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Input" value={colors.bgInput ?? ""} onChange={(v) => set("bgInput", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Input Off" value={colors.bgInputOff ?? ""} onChange={(v) => set("bgInputOff", v)} optional placeholder="auto" />
+
+          <div className="color-group-label">Borders</div>
+          <ColorPickerInput label="Border" value={colors.border ?? ""} onChange={(v) => set("border", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Border Focus" value={colors.borderFocus ?? ""} onChange={(v) => set("borderFocus", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Border Subtle" value={colors.borderSubtle ?? ""} onChange={(v) => set("borderSubtle", v)} optional placeholder="auto" />
+
+          <div className="color-group-label">Text</div>
+          <ColorPickerInput label="Primary" value={colors.textPrimary} onChange={(v) => onColorsChange({ ...colors, textPrimary: v })} />
+          <ColorPickerInput label="Muted" value={colors.textMuted ?? ""} onChange={(v) => set("textMuted", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Dim" value={colors.textDim ?? ""} onChange={(v) => set("textDim", v)} optional placeholder="auto" />
+
+          <div className="color-group-label">Accents</div>
+          <ColorPickerInput label="Green" value={colors.accentGreen} onChange={(v) => onColorsChange({ ...colors, accentGreen: v })} />
+          <ColorPickerInput label="Yellow" value={colors.accentYellow} onChange={(v) => onColorsChange({ ...colors, accentYellow: v })} />
+          <ColorPickerInput label="Red" value={colors.accentRed} onChange={(v) => onColorsChange({ ...colors, accentRed: v })} />
+
+          <div className="color-group-label">Status</div>
+          <ColorPickerInput label="Success" value={colors.statusSuccess ?? ""} onChange={(v) => set("statusSuccess", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Error" value={colors.statusError ?? ""} onChange={(v) => set("statusError", v)} optional placeholder="auto" />
+
+          <div className="color-group-label">Radius</div>
+          <div className="color-picker-row">
+            <span className="color-picker-label">Small</span>
+            <input
+              type="text"
+              className="color-picker-text color-picker-text--full"
+              value={colors.radiusSm ?? ""}
+              placeholder="0.375rem"
+              onChange={(e) => set("radiusSm", e.target.value)}
+            />
+          </div>
+          <div className="color-picker-row">
+            <span className="color-picker-label">Medium</span>
+            <input
+              type="text"
+              className="color-picker-text color-picker-text--full"
+              value={colors.radiusMd ?? ""}
+              placeholder="0.625rem"
+              onChange={(e) => set("radiusMd", e.target.value)}
+            />
+          </div>
+          <div className="color-picker-row">
+            <span className="color-picker-label">Large</span>
+            <input
+              type="text"
+              className="color-picker-text color-picker-text--full"
+              value={colors.radiusLg ?? ""}
+              placeholder="0.875rem"
+              onChange={(e) => set("radiusLg", e.target.value)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CustomThemeEditor.tsx
+++ b/src/components/CustomThemeEditor.tsx
@@ -1,6 +1,14 @@
 import "./CustomThemeEditor.css";
+import { useEffect, useRef, useState } from "react";
 import type { CustomThemeColors } from "../store";
+import { DEFAULT_SETTINGS } from "../store";
 import ColorPickerInput from "./ColorPickerInput";
+import {
+  getAutoKofiStyle,
+  THEME_PRESETS,
+  validateRadius,
+  sanitizeImportedTheme,
+} from "../utils/theme";
 
 interface Props {
   colors: CustomThemeColors;
@@ -9,10 +17,152 @@ interface Props {
   onModeChange: (m: "basic" | "advanced") => void;
 }
 
-export default function CustomThemeEditor({ colors, mode, onColorsChange, onModeChange }: Props) {
+const UNDO_MS = 6000;
+
+interface RadiusInputProps {
+  label: string;
+  value: string;
+  placeholder: string;
+  onCommit: (v: string) => void;
+}
+
+function RadiusInput({ label, value, placeholder, onCommit }: RadiusInputProps) {
+  const [text, setText] = useState(value);
+  const [invalid, setInvalid] = useState(false);
+  useEffect(() => {
+    setText(value);
+    setInvalid(false);
+  }, [value]);
+
+  return (
+    <div className="color-picker-row">
+      <span className="color-picker-label">{label}</span>
+      <input
+        type="text"
+        className={`color-picker-text color-picker-text--full ${invalid ? "color-picker-text--invalid" : ""}`}
+        value={text}
+        placeholder={placeholder}
+        spellCheck={false}
+        onChange={(e) => {
+          setText(e.target.value);
+          if (invalid) setInvalid(false);
+        }}
+        onBlur={() => {
+          if (validateRadius(text)) {
+            setInvalid(false);
+            onCommit(text);
+          } else {
+            setInvalid(true);
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+export default function CustomThemeEditor({
+  colors,
+  mode,
+  onColorsChange,
+  onModeChange,
+}: Props) {
+  const [undoSnap, setUndoSnap] = useState<CustomThemeColors | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [showImport, setShowImport] = useState(false);
+  const [importText, setImportText] = useState("");
+  const [importError, setImportError] = useState<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    };
+  }, []);
+
+  const showToast = (msg: string, ms = 2500) => {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    setToast(msg);
+    toastTimerRef.current = setTimeout(() => setToast(null), ms);
+  };
+
+  const startUndo = (snapshot: CustomThemeColors) => {
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    setUndoSnap(snapshot);
+    undoTimerRef.current = setTimeout(() => setUndoSnap(null), UNDO_MS);
+  };
+
   const set = (key: keyof CustomThemeColors, value: string) => {
     onColorsChange({ ...colors, [key]: value || undefined });
   };
+
+  const handleReset = () => {
+    startUndo(colors);
+    onColorsChange(DEFAULT_SETTINGS.customTheme);
+  };
+
+  const handleUndo = () => {
+    if (!undoSnap) return;
+    onColorsChange(undoSnap);
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    setUndoSnap(null);
+  };
+
+  const isPresetActive = (presetColors: CustomThemeColors) =>
+    colors.bgBase === presetColors.bgBase &&
+    colors.textPrimary === presetColors.textPrimary &&
+    colors.accentGreen === presetColors.accentGreen &&
+    colors.accentYellow === presetColors.accentYellow &&
+    colors.accentRed === presetColors.accentRed;
+
+  const handlePreset = (presetColors: CustomThemeColors) => {
+    startUndo(colors);
+    onColorsChange({ ...presetColors });
+  };
+
+  const handleExport = async () => {
+    const json = JSON.stringify(colors, null, 2);
+    try {
+      await navigator.clipboard.writeText(json);
+      showToast("Copied theme to clipboard");
+    } catch {
+      showToast("Copy failed — clipboard unavailable");
+    }
+  };
+
+  const handleImportApply = () => {
+    setImportError(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(importText);
+    } catch {
+      setImportError("Invalid JSON");
+      return;
+    }
+    const sanitized = sanitizeImportedTheme(parsed);
+    if (!sanitized) {
+      setImportError("Missing required colors");
+      return;
+    }
+    startUndo(colors);
+    onColorsChange(sanitized);
+    setImportText("");
+    setShowImport(false);
+    showToast("Theme imported");
+  };
+
+  const handleImportFromClipboard = async () => {
+    try {
+      const txt = await navigator.clipboard.readText();
+      setImportText(txt);
+      setImportError(null);
+    } catch {
+      setImportError("Clipboard unavailable — paste manually");
+    }
+  };
+
+  const effectiveKofiStyle = colors.kofiStyle ?? getAutoKofiStyle(colors.bgBase);
 
   return (
     <div className="custom-theme-editor">
@@ -28,6 +178,36 @@ export default function CustomThemeEditor({ colors, mode, onColorsChange, onMode
             </button>
           ))}
         </div>
+        <button
+          className="theme-reset-btn"
+          onClick={handleReset}
+          title="Reset to defaults"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className="theme-presets">
+        <span className="theme-presets-label">Presets</span>
+        <div className="theme-presets-grid">
+          {THEME_PRESETS.map((p) => (
+            <button
+              key={p.name}
+              className={`theme-preset-btn${isPresetActive(p.colors) ? " theme-preset-btn--active" : ""}`}
+              onClick={() => handlePreset(p.colors)}
+              title={`Apply ${p.name}`}
+            >
+              <span
+                className="theme-preset-swatch"
+                style={{
+                  background: `linear-gradient(135deg, ${p.colors.bgBase} 0 50%, ${p.colors.accentGreen} 50% 100%)`,
+                  borderColor: p.colors.textPrimary,
+                }}
+              />
+              <span className="theme-preset-name">{p.name}</span>
+            </button>
+          ))}
+        </div>
       </div>
 
       {mode === "basic" ? (
@@ -36,89 +216,160 @@ export default function CustomThemeEditor({ colors, mode, onColorsChange, onMode
             label="Background"
             value={colors.bgBase}
             onChange={(v) => onColorsChange({ ...colors, bgBase: v })}
+            allowAlpha
           />
           <ColorPickerInput
             label="Text Color"
             value={colors.textPrimary}
             onChange={(v) => onColorsChange({ ...colors, textPrimary: v })}
+            allowAlpha
           />
           <ColorPickerInput
             label="Green Accent"
             value={colors.accentGreen}
             onChange={(v) => onColorsChange({ ...colors, accentGreen: v })}
+            allowAlpha
           />
           <ColorPickerInput
             label="Yellow Accent"
             value={colors.accentYellow}
             onChange={(v) => onColorsChange({ ...colors, accentYellow: v })}
+            allowAlpha
           />
           <ColorPickerInput
             label="Red Accent"
             value={colors.accentRed}
             onChange={(v) => onColorsChange({ ...colors, accentRed: v })}
+            allowAlpha
           />
         </div>
       ) : (
         <div className="color-grid color-grid--advanced">
           <div className="color-group-label">Backgrounds</div>
-          <ColorPickerInput label="Base" value={colors.bgBase} onChange={(v) => onColorsChange({ ...colors, bgBase: v })} />
-          <ColorPickerInput label="Surface" value={colors.bgSurface ?? ""} onChange={(v) => set("bgSurface", v)} optional placeholder="auto" />
-          <ColorPickerInput label="Elevated" value={colors.bgElevated ?? ""} onChange={(v) => set("bgElevated", v)} optional placeholder="auto" />
-          <ColorPickerInput label="Input" value={colors.bgInput ?? ""} onChange={(v) => set("bgInput", v)} optional placeholder="auto" />
-          <ColorPickerInput label="Input Off" value={colors.bgInputOff ?? ""} onChange={(v) => set("bgInputOff", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Base" value={colors.bgBase} onChange={(v) => onColorsChange({ ...colors, bgBase: v })} allowAlpha />
+          <ColorPickerInput label="Surface" value={colors.bgSurface ?? ""} onChange={(v) => set("bgSurface", v)} optional placeholder="auto" allowAlpha />
+          <ColorPickerInput label="Elevated" value={colors.bgElevated ?? ""} onChange={(v) => set("bgElevated", v)} optional placeholder="auto" allowAlpha />
+          <ColorPickerInput label="Input" value={colors.bgInput ?? ""} onChange={(v) => set("bgInput", v)} optional placeholder="auto" allowAlpha />
+          <ColorPickerInput label="Input Off" value={colors.bgInputOff ?? ""} onChange={(v) => set("bgInputOff", v)} optional placeholder="auto" allowAlpha />
 
           <div className="color-group-label">Borders</div>
-          <ColorPickerInput label="Border" value={colors.border ?? ""} onChange={(v) => set("border", v)} optional placeholder="auto" />
-          <ColorPickerInput label="Border Focus" value={colors.borderFocus ?? ""} onChange={(v) => set("borderFocus", v)} optional placeholder="auto" />
-          <ColorPickerInput label="Border Subtle" value={colors.borderSubtle ?? ""} onChange={(v) => set("borderSubtle", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Border" value={colors.border ?? ""} onChange={(v) => set("border", v)} optional placeholder="auto" allowAlpha />
+          <ColorPickerInput label="Border Focus" value={colors.borderFocus ?? ""} onChange={(v) => set("borderFocus", v)} optional placeholder="auto" allowAlpha />
+          <ColorPickerInput label="Border Subtle" value={colors.borderSubtle ?? ""} onChange={(v) => set("borderSubtle", v)} optional placeholder="auto" allowAlpha />
 
           <div className="color-group-label">Text</div>
-          <ColorPickerInput label="Primary" value={colors.textPrimary} onChange={(v) => onColorsChange({ ...colors, textPrimary: v })} />
-          <ColorPickerInput label="Muted" value={colors.textMuted ?? ""} onChange={(v) => set("textMuted", v)} optional placeholder="auto" />
-          <ColorPickerInput label="Dim" value={colors.textDim ?? ""} onChange={(v) => set("textDim", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Primary" value={colors.textPrimary} onChange={(v) => onColorsChange({ ...colors, textPrimary: v })} allowAlpha />
+          <ColorPickerInput label="Muted" value={colors.textMuted ?? ""} onChange={(v) => set("textMuted", v)} optional placeholder="auto" allowAlpha />
+          <ColorPickerInput label="Dim" value={colors.textDim ?? ""} onChange={(v) => set("textDim", v)} optional placeholder="auto" allowAlpha />
 
           <div className="color-group-label">Accents</div>
-          <ColorPickerInput label="Green" value={colors.accentGreen} onChange={(v) => onColorsChange({ ...colors, accentGreen: v })} />
-          <ColorPickerInput label="Yellow" value={colors.accentYellow} onChange={(v) => onColorsChange({ ...colors, accentYellow: v })} />
-          <ColorPickerInput label="Red" value={colors.accentRed} onChange={(v) => onColorsChange({ ...colors, accentRed: v })} />
+          <ColorPickerInput label="Green" value={colors.accentGreen} onChange={(v) => onColorsChange({ ...colors, accentGreen: v })} allowAlpha />
+          <ColorPickerInput label="Yellow" value={colors.accentYellow} onChange={(v) => onColorsChange({ ...colors, accentYellow: v })} allowAlpha />
+          <ColorPickerInput label="Red" value={colors.accentRed} onChange={(v) => onColorsChange({ ...colors, accentRed: v })} allowAlpha />
 
           <div className="color-group-label">Status</div>
-          <ColorPickerInput label="Success" value={colors.statusSuccess ?? ""} onChange={(v) => set("statusSuccess", v)} optional placeholder="auto" />
-          <ColorPickerInput label="Error" value={colors.statusError ?? ""} onChange={(v) => set("statusError", v)} optional placeholder="auto" />
+          <ColorPickerInput label="Success" value={colors.statusSuccess ?? ""} onChange={(v) => set("statusSuccess", v)} optional placeholder="auto" allowAlpha />
+          <ColorPickerInput label="Error" value={colors.statusError ?? ""} onChange={(v) => set("statusError", v)} optional placeholder="auto" allowAlpha />
 
           <div className="color-group-label">Radius</div>
-          <div className="color-picker-row">
-            <span className="color-picker-label">Small</span>
-            <input
-              type="text"
-              className="color-picker-text color-picker-text--full"
-              value={colors.radiusSm ?? ""}
-              placeholder="0.375rem"
-              onChange={(e) => set("radiusSm", e.target.value)}
-            />
+          <RadiusInput label="Small" value={colors.radiusSm ?? ""} placeholder="0.375rem" onCommit={(v) => set("radiusSm", v)} />
+          <RadiusInput label="Medium" value={colors.radiusMd ?? ""} placeholder="0.625rem" onCommit={(v) => set("radiusMd", v)} />
+          <RadiusInput label="Large" value={colors.radiusLg ?? ""} placeholder="0.875rem" onCommit={(v) => set("radiusLg", v)} />
+        </div>
+      )}
+
+      <div className="color-grid">
+        <div className="color-group-label kofi-section-label">Ko-fi Button</div>
+        <div className="color-picker-row">
+          <span className="color-picker-label">Style</span>
+          <div className="kofi-picker">
+            <button
+              className={`kofi-option kofi-option--auto ${!colors.kofiStyle ? "active" : ""}`}
+              onClick={() => {
+                const { kofiStyle: _k, ...rest } = colors;
+                onColorsChange(rest as CustomThemeColors);
+              }}
+              title="Auto"
+            >
+              Auto
+            </button>
+            {(["1", "2", "3", "4", "5", "6"] as const).map((n) => (
+              <button
+                key={n}
+                className={`kofi-option ${
+                  colors.kofiStyle === n
+                    ? "active"
+                    : !colors.kofiStyle && effectiveKofiStyle === n
+                    ? "auto-active"
+                    : ""
+                }`}
+                onClick={() => onColorsChange({ ...colors, kofiStyle: n })}
+                title={["Dark", "Yellow", "White", "Purple", "Blue", "Orange"][+n - 1]}
+              >
+                <img
+                  src={`https://storage.ko-fi.com/cdn/kofi${n}.png?v=6`}
+                  alt={`kofi${n}`}
+                  height="20"
+                />
+              </button>
+            ))}
           </div>
-          <div className="color-picker-row">
-            <span className="color-picker-label">Medium</span>
-            <input
-              type="text"
-              className="color-picker-text color-picker-text--full"
-              value={colors.radiusMd ?? ""}
-              placeholder="0.625rem"
-              onChange={(e) => set("radiusMd", e.target.value)}
-            />
-          </div>
-          <div className="color-picker-row">
-            <span className="color-picker-label">Large</span>
-            <input
-              type="text"
-              className="color-picker-text color-picker-text--full"
-              value={colors.radiusLg ?? ""}
-              placeholder="0.875rem"
-              onChange={(e) => set("radiusLg", e.target.value)}
-            />
+        </div>
+      </div>
+
+      <div className="theme-io">
+        <button className="theme-io-btn" onClick={handleExport} title="Copy theme JSON to clipboard">
+          Export
+        </button>
+        <button
+          className="theme-io-btn"
+          onClick={() => {
+            setShowImport((s) => !s);
+            setImportError(null);
+          }}
+        >
+          {showImport ? "Cancel" : "Import"}
+        </button>
+      </div>
+
+      {showImport && (
+        <div className="theme-import-panel">
+          <textarea
+            className="theme-import-textarea"
+            placeholder="Paste theme JSON here…"
+            value={importText}
+            onChange={(e) => {
+              setImportText(e.target.value);
+              if (importError) setImportError(null);
+            }}
+            spellCheck={false}
+            rows={4}
+          />
+          {importError && <div className="theme-import-error">{importError}</div>}
+          <div className="theme-import-actions">
+            <button className="theme-io-btn" onClick={handleImportFromClipboard}>
+              From clipboard
+            </button>
+            <button
+              className="theme-io-btn theme-io-btn--primary"
+              onClick={handleImportApply}
+              disabled={!importText.trim()}
+            >
+              Apply
+            </button>
           </div>
         </div>
       )}
+
+      {undoSnap && (
+        <div className="theme-toast">
+          <span>Theme changed</span>
+          <button className="theme-toast-undo" onClick={handleUndo}>
+            Undo
+          </button>
+        </div>
+      )}
+      {!undoSnap && toast && <div className="theme-toast theme-toast--info">{toast}</div>}
     </div>
   );
 }

--- a/src/components/CustomThemeEditor.tsx
+++ b/src/components/CustomThemeEditor.tsx
@@ -8,6 +8,7 @@ import {
   THEME_PRESETS,
   validateRadius,
   sanitizeImportedTheme,
+  fileToBackgroundDataUrl,
 } from "../utils/theme";
 
 interface Props {
@@ -73,6 +74,37 @@ export default function CustomThemeEditor({
   const [showImport, setShowImport] = useState(false);
   const [importText, setImportText] = useState("");
   const [importError, setImportError] = useState<string | null>(null);
+  const bgFileRef = useRef<HTMLInputElement | null>(null);
+  const [bgBusy, setBgBusy] = useState(false);
+
+  const handleBgPick = async (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      showToast("Only image files are supported");
+      return;
+    }
+    setBgBusy(true);
+    try {
+      const dataUrl = await fileToBackgroundDataUrl(file);
+      onColorsChange({
+        ...colors,
+        backgroundImage: dataUrl,
+        backgroundOpacity: colors.backgroundOpacity ?? 30,
+        backgroundBlur: colors.backgroundBlur ?? 0,
+      });
+      showToast("Background image saved");
+    } catch (err) {
+      console.error("Failed to load image:", err);
+      showToast("Failed to load image");
+    } finally {
+      setBgBusy(false);
+      if (bgFileRef.current) bgFileRef.current.value = "";
+    }
+  };
+
+  const handleBgRemove = () => {
+    const { backgroundImage: _img, backgroundOpacity: _o, backgroundBlur: _b, ...rest } = colors;
+    onColorsChange(rest as CustomThemeColors);
+  };
 
   useEffect(() => {
     return () => {
@@ -279,6 +311,115 @@ export default function CustomThemeEditor({
       )}
 
       <div className="color-grid">
+        <div className="color-group-label kofi-section-label">Background Image</div>
+        <div className="bg-image-row">
+          {colors.backgroundImage ? (
+            <div
+              className="bg-image-preview"
+              style={{ backgroundImage: `url("${colors.backgroundImage}")` }}
+            />
+          ) : (
+            <div className="bg-image-preview bg-image-preview--empty">No image</div>
+          )}
+          <div className="bg-image-actions">
+            <button
+              className="theme-io-btn"
+              onClick={() => bgFileRef.current?.click()}
+              disabled={bgBusy}
+            >
+              {colors.backgroundImage ? "Change" : "Select image"}
+            </button>
+            {colors.backgroundImage && (
+              <button
+                className="theme-io-btn"
+                onClick={handleBgRemove}
+                disabled={bgBusy}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+          <input
+            ref={bgFileRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) void handleBgPick(file);
+            }}
+          />
+        </div>
+        {colors.backgroundImage && (
+          <>
+            <div className="color-picker-row">
+              <span className="color-picker-label">Opacity</span>
+              <div className="color-picker-alpha">
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  step={1}
+                  value={colors.backgroundOpacity ?? 30}
+                  onChange={(e) =>
+                    onColorsChange({
+                      ...colors,
+                      backgroundOpacity: parseInt(e.target.value, 10),
+                    })
+                  }
+                  className="color-picker-alpha-range"
+                />
+                <span className="color-picker-alpha-value">
+                  {colors.backgroundOpacity ?? 30}%
+                </span>
+              </div>
+            </div>
+            <div className="color-picker-row">
+              <span className="color-picker-label">Blur</span>
+              <div className="color-picker-alpha">
+                <input
+                  type="range"
+                  min={0}
+                  max={10}
+                  step={0.1}
+                  value={colors.backgroundBlur ?? 0}
+                  onChange={(e) =>
+                    onColorsChange({
+                      ...colors,
+                      backgroundBlur: parseFloat(e.target.value),
+                    })
+                  }
+                  className="color-picker-alpha-range"
+                />
+                <span className="color-picker-alpha-value">
+                  {(colors.backgroundBlur ?? 0).toFixed(1)}px
+                </span>
+              </div>
+            </div>
+          </>
+        )}
+        <div className="color-picker-row">
+          <span className="color-picker-label">Panel opacity</span>
+          <div className="color-picker-alpha">
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={colors.panelOpacity ?? 100}
+              onChange={(e) =>
+                onColorsChange({
+                  ...colors,
+                  panelOpacity: parseInt(e.target.value, 10),
+                })
+              }
+              className="color-picker-alpha-range"
+            />
+            <span className="color-picker-alpha-value">
+              {colors.panelOpacity ?? 100}%
+            </span>
+          </div>
+        </div>
         <div className="color-group-label kofi-section-label">Ko-fi Button</div>
         <div className="color-picker-row">
           <span className="color-picker-label">Style</span>

--- a/src/components/TitleBar.css
+++ b/src/components/TitleBar.css
@@ -33,10 +33,10 @@
 }
 
 .window-title-background[data-running="true"] .window-title {
-  color: #9ae7ae;
+  color: var(--accent-green);
   text-shadow:
-    0 0 0.625rem rgba(74, 222, 128, 0.2),
-    0 0 1.125rem rgba(74, 222, 128, 0.12);
+    0 0 0.625rem color-mix(in oklab, var(--accent-green) 20%, transparent),
+    0 0 1.125rem color-mix(in oklab, var(--accent-green) 12%, transparent);
 }
 
 .settings-button {

--- a/src/components/panels/SettingsPanel.css
+++ b/src/components/panels/SettingsPanel.css
@@ -207,14 +207,15 @@
   width: 114px;
   height: 30px;
   border-radius: 10px;
-  border: 1px solid var(--border-subtle);
+  border: none;
+  background: transparent;
 }
 
 .social-icon--kofi:hover {
-  color: #72A5F2;
   outline: 2px solid #72A5F2;
-  background: #202020;
+  background: transparent;
 }
+
 
 .social-icon--patreon:hover {
   color: #FF424D;

--- a/src/components/panels/SettingsPanel.tsx
+++ b/src/components/panels/SettingsPanel.tsx
@@ -6,6 +6,33 @@ import { open } from "@tauri-apps/plugin-shell";
 
 const CustomThemeEditor = lazy(() => import("../CustomThemeEditor"));
 
+function getAutoKofiStyle(hex: string): "1" | "2" | "3" | "4" | "5" | "6" {
+  const clean = hex.replace("#", "");
+  const full = clean.length === 3 ? clean.split("").map((c) => c + c).join("") : clean;
+  if (full.length !== 6) return "3";
+  const n = parseInt(full, 16);
+  const r = ((n >> 16) & 255) / 255;
+  const g = ((n >> 8) & 255) / 255;
+  const b = (n & 255) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  const luminance = r * 0.299 + g * 0.587 + b * 0.114;
+  if (max === min) return luminance > 0.5 ? "1" : "3";
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  if (s < 0.15) return luminance > 0.5 ? "1" : "3";
+  let h: number;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
+  else if (max === g) h = ((b - r) / d + 2) * 60;
+  else h = ((r - g) / d + 4) * 60;
+  if (h < 30 || h >= 330) return "6";
+  if (h < 70) return "2";
+  if (h < 165) return luminance > 0.5 ? "1" : "3";
+  if (h < 255) return "5";
+  return "4";
+}
+
 interface CumulativeStats {
   totalClicks: number;
   totalTimeSecs: number;
@@ -89,11 +116,17 @@ export default function SettingsPanel({
               <img
                 height="28"
                 style={{ border: 0, height: "28px" }}
-                src={
-                  settings.theme === "light"
+                src={(() => {
+                  if (settings.theme === "custom") {
+                    if (settings.customTheme.kofiStyle) {
+                      return `https://storage.ko-fi.com/cdn/kofi${settings.customTheme.kofiStyle}.png?v=6`;
+                    }
+                    return `https://storage.ko-fi.com/cdn/kofi${getAutoKofiStyle(settings.customTheme.bgBase)}.png?v=6`;
+                  }
+                  return settings.theme === "light"
                     ? "https://storage.ko-fi.com/cdn/kofi1.png?v=6"
-                    : "https://storage.ko-fi.com/cdn/kofi3.png?v=6"
-                }
+                    : "https://storage.ko-fi.com/cdn/kofi3.png?v=6";
+                })()}
                 alt="Buy Me a Coffee at ko-fi.com"
               />
             </a>

--- a/src/components/panels/SettingsPanel.tsx
+++ b/src/components/panels/SettingsPanel.tsx
@@ -1,8 +1,10 @@
 import "./SettingsPanel.css";
-import type { AppInfo, Settings } from "../../store";
+import type { AppInfo, Settings, Theme } from "../../store";
 import { invoke } from "@tauri-apps/api/core";
-import { useEffect, useRef, useState } from "react";
+import { lazy, useEffect, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-shell";
+
+const CustomThemeEditor = lazy(() => import("../CustomThemeEditor"));
 
 interface CumulativeStats {
   totalClicks: number;
@@ -87,7 +89,11 @@ export default function SettingsPanel({
               <img
                 height="28"
                 style={{ border: 0, height: "28px" }}
-                src="https://storage.ko-fi.com/cdn/kofi3.png?v=6"
+                src={
+                  settings.theme === "light"
+                    ? "https://storage.ko-fi.com/cdn/kofi1.png?v=6"
+                    : "https://storage.ko-fi.com/cdn/kofi3.png?v=6"
+                }
                 alt="Buy Me a Coffee at ko-fi.com"
               />
             </a>
@@ -279,23 +285,29 @@ export default function SettingsPanel({
           <div className="settings-label-group">
             <span className="settings-label">Theme</span>
             <span className="settings-sublabel">
-              Switch between Dark and light themes.
+              Switch between Dark, Light, or create a Custom theme.
             </span>
           </div>
           <div className="settings-seg-group">
-            {(["Dark", "Light"] as const).map((o) => (
+            {(["Dark", "Light", "Custom"] as const).map((o) => (
               <button
                 key={o}
-                className={`settings-seg-btn ${(settings.theme === "light" ? "Light" : "Dark") === o ? "active" : ""}`}
-                onClick={() =>
-                  update({ theme: o.toLowerCase() as "dark" | "light" })
-                }
+                className={`settings-seg-btn ${settings.theme === o.toLowerCase() ? "active" : ""}`}
+                onClick={() => update({ theme: o.toLowerCase() as Theme })}
               >
                 {o}
               </button>
             ))}
           </div>
         </div>
+        {settings.theme === "custom" && (
+          <CustomThemeEditor
+            colors={settings.customTheme}
+            mode={settings.customThemeMode ?? "basic"}
+            onColorsChange={(c) => update({ customTheme: c })}
+            onModeChange={(m) => update({ customThemeMode: m })}
+          />
+        )}
         <div className="settings-divider" />
         <div className="settings-row">
           <div className="settings-label-group">

--- a/src/components/panels/SettingsPanel.tsx
+++ b/src/components/panels/SettingsPanel.tsx
@@ -3,35 +3,9 @@ import type { AppInfo, Settings, Theme } from "../../store";
 import { invoke } from "@tauri-apps/api/core";
 import { lazy, useEffect, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-shell";
+import { getAutoKofiStyle } from "../../utils/theme";
 
 const CustomThemeEditor = lazy(() => import("../CustomThemeEditor"));
-
-function getAutoKofiStyle(hex: string): "1" | "2" | "3" | "4" | "5" | "6" {
-  const clean = hex.replace("#", "");
-  const full = clean.length === 3 ? clean.split("").map((c) => c + c).join("") : clean;
-  if (full.length !== 6) return "3";
-  const n = parseInt(full, 16);
-  const r = ((n >> 16) & 255) / 255;
-  const g = ((n >> 8) & 255) / 255;
-  const b = (n & 255) / 255;
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const l = (max + min) / 2;
-  const luminance = r * 0.299 + g * 0.587 + b * 0.114;
-  if (max === min) return luminance > 0.5 ? "1" : "3";
-  const d = max - min;
-  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-  if (s < 0.15) return luminance > 0.5 ? "1" : "3";
-  let h: number;
-  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
-  else if (max === g) h = ((b - r) / d + 2) * 60;
-  else h = ((r - g) / d + 4) * 60;
-  if (h < 30 || h >= 330) return "6";
-  if (h < 70) return "2";
-  if (h < 165) return luminance > 0.5 ? "1" : "3";
-  if (h < 255) return "5";
-  return "4";
-}
 
 interface CumulativeStats {
   totalClicks: number;

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,29 @@
   --status-error: hsl(4, 100%, 71%);
 }
 
+[data-theme="custom"] {
+  --theme-tint: #fff;
+  --bg-surface:    color-mix(in oklab, var(--bg-base) 95%, var(--theme-tint));
+  --bg-elevated:   color-mix(in oklab, var(--bg-base) 90%, var(--theme-tint));
+  --bg-input:      color-mix(in oklab, var(--bg-base) 80%, var(--theme-tint));
+  --bg-input-off:  color-mix(in oklab, var(--bg-base) 85%, var(--theme-tint));
+  --border:        color-mix(in oklab, var(--bg-base) 72%, var(--theme-tint));
+  --border-focus:  color-mix(in oklab, var(--bg-base) 65%, var(--theme-tint));
+  --border-subtle: color-mix(in oklab, var(--bg-base) 80%, var(--theme-tint));
+  --text-muted:    color-mix(in oklab, var(--text-primary) 60%, transparent);
+  --text-dim:      color-mix(in oklab, var(--text-primary) 35%, transparent);
+  --status-success: var(--accent-green);
+  --status-error: var(--accent-red);
+  --container-shadow: 0 2px 0.5rem rgba(0, 0, 0, 0.3);
+  --divider-color: color-mix(in oklab, var(--text-primary) 25%, transparent);
+  --radius-sm: 0.375rem;
+  --radius-md: 0.625rem;
+  --radius-lg: 0.875rem;
+  --update-banner-bg: color-mix(in oklab, var(--accent-yellow) 40%, var(--bg-base));
+  --update-banner-text-fg: var(--text-primary);
+  --update-banner-text-bg: color-mix(in oklab, var(--text-primary) 80%, transparent);
+}
+
 [data-theme="light"] {
   --bg-base:       hsl(0, 0%, 100%);
   --bg-surface:    hsl(0, 0%, 100%);

--- a/src/index.css
+++ b/src/index.css
@@ -132,6 +132,25 @@ body {
   min-height: 0;
 }
 
+[data-theme="custom"] .app-root::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: var(--theme-bg-image, none);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  opacity: var(--theme-bg-opacity, 0);
+  filter: blur(var(--theme-bg-blur, 0));
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 0;
+}
+
+[data-theme="custom"] .app-root > * {
+  position: relative;
+  z-index: 1;
+}
 .panel-area {
   flex: 1;
   padding: 1.25rem 1.25rem 1.25rem 1.25rem;

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,7 +7,31 @@ export const APP_VERSION = await getVersion();
 
 export type SavedPanel = "simple" | "advanced";
 export type ExplanationMode = "off" | "text";
-export type Theme = "dark" | "light";
+export type Theme = "dark" | "light" | "custom";
+
+export interface CustomThemeColors {
+  bgBase: string;
+  textPrimary: string;
+  accentGreen: string;
+  accentYellow: string;
+  accentRed: string;
+  bgSurface?: string;
+  bgElevated?: string;
+  bgInput?: string;
+  bgInputOff?: string;
+  border?: string;
+  borderFocus?: string;
+  borderSubtle?: string;
+  textMuted?: string;
+  textDim?: string;
+  radiusSm?: string;
+  radiusMd?: string;
+  radiusLg?: string;
+  containerShadow?: string;
+  dividerColor?: string;
+  statusSuccess?: string;
+  statusError?: string;
+}
 
 export interface Settings {
   version: string;
@@ -48,6 +72,8 @@ export interface Settings {
   showStopOverlay: boolean;
   strictHotkeyModifiers: boolean;
   theme: Theme;
+  customTheme: CustomThemeColors;
+  customThemeMode: "basic" | "advanced";
 }
 
 export interface ClickerStatus {
@@ -102,6 +128,14 @@ export const DEFAULT_SETTINGS: Settings = {
   showStopOverlay: true,
   strictHotkeyModifiers: false,
   theme: "dark",
+  customTheme: {
+    bgBase: "#121212",
+    textPrimary: "#f9fefe",
+    accentGreen: "hsla(129, 77%, 43%, 0.75)",
+    accentYellow: "hsla(41, 99%, 59%, 0.75)",
+    accentRed: "hsla(4, 100%, 71%, 0.75)",
+  },
+  customThemeMode: "basic",
 };
 
 function sanitizeSavedPanel(value: unknown): SavedPanel {
@@ -234,7 +268,38 @@ function sanitizeSettings(input?: Partial<Settings> | null): Settings {
     disableScreenshots: false,
     explanationMode: sanitizeExplanationMode(saved),
     lastPanel: sanitizeSavedPanel(saved.lastPanel),
-    theme: saved.theme === "light" ? "light" : "dark",
+    theme: saved.theme === "light" ? "light" : saved.theme === "custom" ? "custom" : "dark",
+    customTheme: sanitizeCustomThemeColors(saved.customTheme),
+    customThemeMode: saved.customThemeMode === "advanced" ? "advanced" : "basic",
+  };
+}
+
+function sanitizeCustomThemeColors(input: unknown): CustomThemeColors {
+  const c = (typeof input === "object" && input !== null ? input : {}) as Partial<CustomThemeColors>;
+  const isHex = (v: unknown) => typeof v === "string" && /^#[0-9a-fA-F]{3,8}$/.test(v);
+  const isColor = (v: unknown) => typeof v === "string" && v.trim().length > 0;
+  return {
+    bgBase: isHex(c.bgBase) ? c.bgBase! : DEFAULT_SETTINGS.customTheme.bgBase,
+    textPrimary: isColor(c.textPrimary) ? c.textPrimary! : DEFAULT_SETTINGS.customTheme.textPrimary,
+    accentGreen: isColor(c.accentGreen) ? c.accentGreen! : DEFAULT_SETTINGS.customTheme.accentGreen,
+    accentYellow: isColor(c.accentYellow) ? c.accentYellow! : DEFAULT_SETTINGS.customTheme.accentYellow,
+    accentRed: isColor(c.accentRed) ? c.accentRed! : DEFAULT_SETTINGS.customTheme.accentRed,
+    ...(isColor(c.bgSurface) && { bgSurface: c.bgSurface }),
+    ...(isColor(c.bgElevated) && { bgElevated: c.bgElevated }),
+    ...(isColor(c.bgInput) && { bgInput: c.bgInput }),
+    ...(isColor(c.bgInputOff) && { bgInputOff: c.bgInputOff }),
+    ...(isColor(c.border) && { border: c.border }),
+    ...(isColor(c.borderFocus) && { borderFocus: c.borderFocus }),
+    ...(isColor(c.borderSubtle) && { borderSubtle: c.borderSubtle }),
+    ...(isColor(c.textMuted) && { textMuted: c.textMuted }),
+    ...(isColor(c.textDim) && { textDim: c.textDim }),
+    ...(isColor(c.radiusSm) && { radiusSm: c.radiusSm }),
+    ...(isColor(c.radiusMd) && { radiusMd: c.radiusMd }),
+    ...(isColor(c.radiusLg) && { radiusLg: c.radiusLg }),
+    ...(isColor(c.containerShadow) && { containerShadow: c.containerShadow }),
+    ...(isColor(c.dividerColor) && { dividerColor: c.dividerColor }),
+    ...(isColor(c.statusSuccess) && { statusSuccess: c.statusSuccess }),
+    ...(isColor(c.statusError) && { statusError: c.statusError }),
   };
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,11 @@
 import { getVersion } from "@tauri-apps/api/app";
 import { LazyStore } from "@tauri-apps/plugin-store";
+import {
+  BG_IMAGE_SENTINEL,
+  clearBgImage,
+  loadBgImage,
+  saveBgImage,
+} from "./utils/bgImageStore";
 
 const store = new LazyStore("settings.json");
 
@@ -37,6 +43,21 @@ export interface CustomThemeColors {
   backgroundBlur?: number;
   panelOpacity?: number;
 }
+
+/**
+ * Optional string/color fields of CustomThemeColors that are handled
+ * generically (no special per-field logic). Keep this list in sync with
+ * the CustomThemeColors interface above — it is the single source of truth
+ * used by both store sanitization and theme import/export helpers.
+ */
+export const THEME_OPTIONAL_KEYS = [
+  "bgSurface", "bgElevated", "bgInput", "bgInputOff",
+  "border", "borderFocus", "borderSubtle",
+  "textMuted", "textDim",
+  "radiusSm", "radiusMd", "radiusLg",
+  "containerShadow", "dividerColor",
+  "statusSuccess", "statusError",
+] as const satisfies ReadonlyArray<keyof CustomThemeColors>;
 
 export interface Settings {
   version: string;
@@ -283,53 +304,81 @@ function sanitizeCustomThemeColors(input: unknown): CustomThemeColors {
   const c = (typeof input === "object" && input !== null ? input : {}) as Partial<CustomThemeColors>;
   const isHex = (v: unknown) => typeof v === "string" && /^#[0-9a-fA-F]{3,8}$/.test(v);
   const isColor = (v: unknown) => typeof v === "string" && v.trim().length > 0;
-  return {
-    bgBase: isHex(c.bgBase) ? c.bgBase! : DEFAULT_SETTINGS.customTheme.bgBase,
-    textPrimary: isColor(c.textPrimary) ? c.textPrimary! : DEFAULT_SETTINGS.customTheme.textPrimary,
-    accentGreen: isColor(c.accentGreen) ? c.accentGreen! : DEFAULT_SETTINGS.customTheme.accentGreen,
-    accentYellow: isColor(c.accentYellow) ? c.accentYellow! : DEFAULT_SETTINGS.customTheme.accentYellow,
-    accentRed: isColor(c.accentRed) ? c.accentRed! : DEFAULT_SETTINGS.customTheme.accentRed,
-    ...(isColor(c.bgSurface) && { bgSurface: c.bgSurface }),
-    ...(isColor(c.bgElevated) && { bgElevated: c.bgElevated }),
-    ...(isColor(c.bgInput) && { bgInput: c.bgInput }),
-    ...(isColor(c.bgInputOff) && { bgInputOff: c.bgInputOff }),
-    ...(isColor(c.border) && { border: c.border }),
-    ...(isColor(c.borderFocus) && { borderFocus: c.borderFocus }),
-    ...(isColor(c.borderSubtle) && { borderSubtle: c.borderSubtle }),
-    ...(isColor(c.textMuted) && { textMuted: c.textMuted }),
-    ...(isColor(c.textDim) && { textDim: c.textDim }),
-    ...(isColor(c.radiusSm) && { radiusSm: c.radiusSm }),
-    ...(isColor(c.radiusMd) && { radiusMd: c.radiusMd }),
-    ...(isColor(c.radiusLg) && { radiusLg: c.radiusLg }),
-    ...(isColor(c.containerShadow) && { containerShadow: c.containerShadow }),
-    ...(isColor(c.dividerColor) && { dividerColor: c.dividerColor }),
-    ...(isColor(c.statusSuccess) && { statusSuccess: c.statusSuccess }),
-    ...(isColor(c.statusError) && { statusError: c.statusError }),
-    ...(["1","2","3","4","5","6"].includes(c.kofiStyle as string) && { kofiStyle: c.kofiStyle }),
-    ...(typeof c.backgroundImage === "string" && c.backgroundImage.startsWith("data:image/") && { backgroundImage: c.backgroundImage }),
-    ...(typeof c.backgroundOpacity === "number" && Number.isFinite(c.backgroundOpacity) && {
-      backgroundOpacity: Math.max(0, Math.min(100, c.backgroundOpacity)),
-    }),
-    ...(typeof c.backgroundBlur === "number" && Number.isFinite(c.backgroundBlur) && {
-      backgroundBlur: Math.max(0, Math.min(10, c.backgroundBlur)),
-    }),
-    ...(typeof c.panelOpacity === "number" && Number.isFinite(c.panelOpacity) && {
-      panelOpacity: Math.max(0, Math.min(100, c.panelOpacity)),
-    }),
+
+  const base: CustomThemeColors = {
+    bgBase:       isHex(c.bgBase)           ? c.bgBase!           : DEFAULT_SETTINGS.customTheme.bgBase,
+    textPrimary:  isColor(c.textPrimary)    ? c.textPrimary!      : DEFAULT_SETTINGS.customTheme.textPrimary,
+    accentGreen:  isColor(c.accentGreen)    ? c.accentGreen!      : DEFAULT_SETTINGS.customTheme.accentGreen,
+    accentYellow: isColor(c.accentYellow)   ? c.accentYellow!     : DEFAULT_SETTINGS.customTheme.accentYellow,
+    accentRed:    isColor(c.accentRed)      ? c.accentRed!        : DEFAULT_SETTINGS.customTheme.accentRed,
   };
+
+  // Optional color fields — include if provided, otherwise CSS fallback is used
+  for (const key of THEME_OPTIONAL_KEYS) {
+    const val = c[key];
+    if (isColor(val)) (base as unknown as Record<string, unknown>)[key] = val;
+  }
+
+  if (["1", "2", "3", "4", "5", "6"].includes(c.kofiStyle as string)) {
+    base.kofiStyle = c.kofiStyle;
+  }
+  if (
+    typeof c.backgroundImage === "string" &&
+    (c.backgroundImage.startsWith("data:image/") || c.backgroundImage === BG_IMAGE_SENTINEL)
+  ) {
+    base.backgroundImage = c.backgroundImage;
+  }
+  if (typeof c.backgroundOpacity === "number" && Number.isFinite(c.backgroundOpacity)) {
+    base.backgroundOpacity = Math.max(0, Math.min(100, c.backgroundOpacity));
+  }
+  if (typeof c.backgroundBlur === "number" && Number.isFinite(c.backgroundBlur)) {
+    base.backgroundBlur = Math.max(0, Math.min(10, c.backgroundBlur));
+  }
+  if (typeof c.panelOpacity === "number" && Number.isFinite(c.panelOpacity)) {
+    base.panelOpacity = Math.max(0, Math.min(100, c.panelOpacity));
+  }
+
+  return base;
 }
 
 export async function loadSettings(): Promise<Settings> {
   const saved = await store.get<Partial<Settings>>("settings");
-  return sanitizeSettings(saved);
+  const settings = sanitizeSettings(saved);
+  // Re-hydrate background image from IndexedDB if it was offloaded
+  if (settings.customTheme.backgroundImage === BG_IMAGE_SENTINEL) {
+    const dataUrl = await loadBgImage();
+    if (dataUrl) {
+      settings.customTheme.backgroundImage = dataUrl;
+    } else {
+      delete settings.customTheme.backgroundImage;
+    }
+  }
+  return settings;
 }
 
 export async function saveSettings(settings: Settings): Promise<void> {
-  await store.set("settings", sanitizeSettings(settings));
+  const sanitized = sanitizeSettings(settings);
+  const bgImage = sanitized.customTheme.backgroundImage;
+  let toStore = sanitized;
+
+  if (bgImage?.startsWith("data:")) {
+    // Keep settings.json small — store the DataURL in IndexedDB instead
+    await saveBgImage(bgImage);
+    toStore = {
+      ...sanitized,
+      customTheme: { ...sanitized.customTheme, backgroundImage: BG_IMAGE_SENTINEL },
+    };
+  } else if (!bgImage) {
+    // Image was removed — clean up IndexedDB entry too
+    await clearBgImage().catch(() => { /* non-critical */ });
+  }
+
+  await store.set("settings", toStore);
   await store.save();
 }
 
 export async function clearSavedSettings(): Promise<void> {
+  await clearBgImage().catch(() => { /* non-critical */ });
   await store.set("settings", DEFAULT_SETTINGS);
   await store.save();
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -32,6 +32,10 @@ export interface CustomThemeColors {
   statusSuccess?: string;
   statusError?: string;
   kofiStyle?: "1" | "2" | "3" | "4" | "5" | "6";
+  backgroundImage?: string;
+  backgroundOpacity?: number;
+  backgroundBlur?: number;
+  panelOpacity?: number;
 }
 
 export interface Settings {
@@ -302,6 +306,16 @@ function sanitizeCustomThemeColors(input: unknown): CustomThemeColors {
     ...(isColor(c.statusSuccess) && { statusSuccess: c.statusSuccess }),
     ...(isColor(c.statusError) && { statusError: c.statusError }),
     ...(["1","2","3","4","5","6"].includes(c.kofiStyle as string) && { kofiStyle: c.kofiStyle }),
+    ...(typeof c.backgroundImage === "string" && c.backgroundImage.startsWith("data:image/") && { backgroundImage: c.backgroundImage }),
+    ...(typeof c.backgroundOpacity === "number" && Number.isFinite(c.backgroundOpacity) && {
+      backgroundOpacity: Math.max(0, Math.min(100, c.backgroundOpacity)),
+    }),
+    ...(typeof c.backgroundBlur === "number" && Number.isFinite(c.backgroundBlur) && {
+      backgroundBlur: Math.max(0, Math.min(10, c.backgroundBlur)),
+    }),
+    ...(typeof c.panelOpacity === "number" && Number.isFinite(c.panelOpacity) && {
+      panelOpacity: Math.max(0, Math.min(100, c.panelOpacity)),
+    }),
   };
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,6 +31,7 @@ export interface CustomThemeColors {
   dividerColor?: string;
   statusSuccess?: string;
   statusError?: string;
+  kofiStyle?: "1" | "2" | "3" | "4" | "5" | "6";
 }
 
 export interface Settings {
@@ -131,9 +132,9 @@ export const DEFAULT_SETTINGS: Settings = {
   customTheme: {
     bgBase: "#121212",
     textPrimary: "#f9fefe",
-    accentGreen: "hsla(129, 77%, 43%, 0.75)",
-    accentYellow: "hsla(41, 99%, 59%, 0.75)",
-    accentRed: "hsla(4, 100%, 71%, 0.75)",
+    accentGreen: "#19c233bf",
+    accentYellow: "#febc2fbf",
+    accentRed: "#ff726bbf",
   },
   customThemeMode: "basic",
 };
@@ -300,6 +301,7 @@ function sanitizeCustomThemeColors(input: unknown): CustomThemeColors {
     ...(isColor(c.dividerColor) && { dividerColor: c.dividerColor }),
     ...(isColor(c.statusSuccess) && { statusSuccess: c.statusSuccess }),
     ...(isColor(c.statusError) && { statusError: c.statusError }),
+    ...(["1","2","3","4","5","6"].includes(c.kofiStyle as string) && { kofiStyle: c.kofiStyle }),
   };
 }
 

--- a/src/utils/bgImageStore.ts
+++ b/src/utils/bgImageStore.ts
@@ -1,0 +1,53 @@
+const DB_NAME = "blur-ac-bg";
+const STORE_NAME = "images";
+const IMAGE_KEY = "background";
+
+/** Sentinel written to settings.json instead of the raw DataURL. */
+export const BG_IMAGE_SENTINEL = "__local__";
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE_NAME);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Persist a background image DataURL to IndexedDB. */
+export async function saveBgImage(dataUrl: string): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).put(dataUrl, IMAGE_KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/**
+ * Load the stored background image DataURL.
+ * Returns `null` if no image has been saved yet.
+ */
+export async function loadBgImage(): Promise<string | null> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const req = tx.objectStore(STORE_NAME).get(IMAGE_KEY);
+    req.onsuccess = () => resolve((req.result as string | undefined) ?? null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Remove the stored background image from IndexedDB. */
+export async function clearBgImage(): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).delete(IMAGE_KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,79 +1,116 @@
-import type { CustomThemeColors } from "../store";
+import { THEME_OPTIONAL_KEYS, type CustomThemeColors } from "../store";
 
 export type KofiStyle = "1" | "2" | "3" | "4" | "5" | "6";
 
-let parseCanvas: HTMLCanvasElement | null = null;
-function getParseCtx(): CanvasRenderingContext2D | null {
-  if (!parseCanvas) parseCanvas = document.createElement("canvas");
-  return parseCanvas.getContext("2d");
-}
-
+/**
+ * Parses any supported CSS color string into an [r, g, b, a] tuple.
+ * Supports: #rgb, #rrggbb, #rrggbbaa, rgb(), rgba().
+ * Pure-regex implementation — no DOM or Canvas dependency.
+ */
 export function parseColorToRgba(
   color: string,
 ): [number, number, number, number] | null {
-  const ctx = getParseCtx();
-  if (!ctx) return null;
-  ctx.fillStyle = "#000";
-  try {
-    ctx.fillStyle = color;
-  } catch {
-    return null;
+  const s = color.trim();
+
+  if (/^#[0-9a-fA-F]{3}$/.test(s)) {
+    return [
+      parseInt(s[1] + s[1], 16),
+      parseInt(s[2] + s[2], 16),
+      parseInt(s[3] + s[3], 16),
+      1,
+    ];
   }
-  const c = ctx.fillStyle;
-  if (typeof c === "string" && c.startsWith("#")) {
-    const hex = c.slice(1);
-    if (hex.length === 6) {
-      const n = parseInt(hex, 16);
-      return [(n >> 16) & 255, (n >> 8) & 255, n & 255, 1];
-    }
-    if (hex.length === 8) {
-      const n = parseInt(hex.slice(0, 6), 16);
-      const a = parseInt(hex.slice(6), 16) / 255;
-      return [(n >> 16) & 255, (n >> 8) & 255, n & 255, a];
-    }
+  if (/^#[0-9a-fA-F]{6}$/.test(s)) {
+    const n = parseInt(s.slice(1), 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255, 1];
   }
-  const m = /rgba?\(([^)]+)\)/.exec(c);
-  if (!m) return null;
-  const parts = m[1].split(",").map((s) => parseFloat(s.trim()));
-  if (parts.length < 3 || parts.some((p) => Number.isNaN(p))) return null;
-  return [parts[0], parts[1], parts[2], parts[3] ?? 1];
+  if (/^#[0-9a-fA-F]{8}$/.test(s)) {
+    const n = parseInt(s.slice(1, 7), 16);
+    const a = parseInt(s.slice(7), 16) / 255;
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255, a];
+  }
+  const m = /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/.exec(s);
+  if (m) {
+    const r = parseFloat(m[1]);
+    const g = parseFloat(m[2]);
+    const b = parseFloat(m[3]);
+    const a = m[4] !== undefined ? parseFloat(m[4]) : 1;
+    if ([r, g, b, a].some(Number.isNaN)) return null;
+    return [r, g, b, a];
+  }
+  return null;
 }
 
-export function getLuminance(color: string): number {
-  const rgba = parseColorToRgba(color);
-  if (!rgba) return 0.5;
-  const [r, g, b] = rgba;
-  return (r * 0.299 + g * 0.587 + b * 0.114) / 255;
+/**
+ * Perceived brightness of a color on a 0–1 scale.
+ * Uses ITU-R BT.601 coefficients on gamma-encoded sRGB — intentionally
+ * simple and fast for UI light/dark decisions.
+ * @param r  red   channel, 0–1
+ * @param g  green channel, 0–1
+ * @param b  blue  channel, 0–1
+ */
+function perceivedBrightness(r: number, g: number, b: number): number {
+  return r * 0.299 + g * 0.587 + b * 0.114;
 }
 
 export function isLightColor(color: string): boolean {
-  return getLuminance(color) > 0.5;
+  const rgba = parseColorToRgba(color);
+  if (!rgba) return false;
+  return perceivedBrightness(rgba[0] / 255, rgba[1] / 255, rgba[2] / 255) > 0.5;
+}
+
+// Ko-fi button style index values — order matches KOFI_TITLES
+const KOFI_STYLE_DARK: KofiStyle   = "1"; // Dark
+const KOFI_STYLE_YELLOW: KofiStyle = "2"; // Yellow
+const KOFI_STYLE_WHITE: KofiStyle  = "3"; // White (default for dark backgrounds)
+const KOFI_STYLE_RED: KofiStyle    = "6"; // Orange (for reddish backgrounds)
+const KOFI_STYLE_BLUE: KofiStyle   = "5"; // Blue
+const KOFI_STYLE_PURPLE: KofiStyle = "4"; // Purple
+
+const LIGHT_LUMINANCE_THRESHOLD = 0.5;
+const GRAYSCALE_SATURATION_THRESHOLD = 0.15;
+
+const HUE_RED_MIN = 330;
+const HUE_RED_MAX = 30;
+const HUE_YELLOW_MAX = 70;
+const HUE_GREEN_MAX = 165;
+const HUE_BLUE_MAX = 255;
+
+function rgbToHsl(r: number, g: number, b: number) {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const lightness = (max + min) / 2;
+  if (max === min) {
+    return { hue: 0, saturation: 0, lightness };
+  }
+  const delta = max - min;
+  const saturation =
+    lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+  let hue: number;
+  if (max === r) hue = ((g - b) / delta + (g < b ? 6 : 0)) * 60;
+  else if (max === g) hue = ((b - r) / delta + 2) * 60;
+  else hue = ((r - g) / delta + 4) * 60;
+  return { hue, saturation, lightness };
 }
 
 export function getAutoKofiStyle(color: string): KofiStyle {
   const rgba = parseColorToRgba(color);
-  if (!rgba) return "3";
-  const [r8, g8, b8] = rgba;
-  const r = r8 / 255;
-  const g = g8 / 255;
-  const b = b8 / 255;
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const l = (max + min) / 2;
-  const luminance = r * 0.299 + g * 0.587 + b * 0.114;
-  if (max === min) return luminance > 0.5 ? "1" : "3";
-  const d = max - min;
-  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-  if (s < 0.15) return luminance > 0.5 ? "1" : "3";
-  let h: number;
-  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
-  else if (max === g) h = ((b - r) / d + 2) * 60;
-  else h = ((r - g) / d + 4) * 60;
-  if (h < 30 || h >= 330) return "6";
-  if (h < 70) return "2";
-  if (h < 165) return luminance > 0.5 ? "1" : "3";
-  if (h < 255) return "5";
-  return "4";
+  if (!rgba) return KOFI_STYLE_WHITE;
+  const r = rgba[0] / 255;
+  const g = rgba[1] / 255;
+  const b = rgba[2] / 255;
+
+  const isLight = perceivedBrightness(r, g, b) > LIGHT_LUMINANCE_THRESHOLD;
+  const defaultStyle = isLight ? KOFI_STYLE_DARK : KOFI_STYLE_WHITE;
+
+  const { hue, saturation } = rgbToHsl(r, g, b);
+  if (saturation < GRAYSCALE_SATURATION_THRESHOLD) return defaultStyle;
+
+  if (hue < HUE_RED_MAX || hue >= HUE_RED_MIN) return KOFI_STYLE_RED;
+  if (hue < HUE_YELLOW_MAX) return KOFI_STYLE_YELLOW;
+  if (hue < HUE_GREEN_MAX) return defaultStyle;
+  if (hue < HUE_BLUE_MAX) return KOFI_STYLE_BLUE;
+  return KOFI_STYLE_PURPLE;
 }
 
 function relativeLuminance(color: string): number {
@@ -299,27 +336,9 @@ export function sanitizeImportedTheme(
     accentYellow: r.accentYellow,
     accentRed: r.accentRed,
   };
-  const optionalKeys: Array<keyof CustomThemeColors> = [
-    "bgSurface",
-    "bgElevated",
-    "bgInput",
-    "bgInputOff",
-    "border",
-    "borderFocus",
-    "borderSubtle",
-    "textMuted",
-    "textDim",
-    "radiusSm",
-    "radiusMd",
-    "radiusLg",
-    "containerShadow",
-    "dividerColor",
-    "statusSuccess",
-    "statusError",
-  ];
-  for (const k of optionalKeys) {
+  for (const k of THEME_OPTIONAL_KEYS) {
     const v = r[k];
-    if (isStr(v)) (out as Record<string, string>)[k] = v;
+    if (isStr(v)) (out as unknown as Record<string, string>)[k] = v;
   }
   if (["1", "2", "3", "4", "5", "6"].includes(r.kofiStyle as string)) {
     out.kofiStyle = r.kofiStyle as KofiStyle;

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -256,6 +256,26 @@ export const THEME_PRESETS: ReadonlyArray<ThemePreset> = [
   },
 ];
 
+export async function fileToBackgroundDataUrl(
+  file: File,
+  maxDim = 1920,
+  quality = 0.85,
+): Promise<string> {
+  const bitmap = await createImageBitmap(file);
+  const scale = Math.min(1, maxDim / Math.max(bitmap.width, bitmap.height));
+  const w = Math.round(bitmap.width * scale);
+  const h = Math.round(bitmap.height * scale);
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D unsupported");
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close?.();
+  const mime = file.type === "image/png" ? "image/png" : "image/jpeg";
+  return canvas.toDataURL(mime, mime === "image/jpeg" ? quality : undefined);
+}
+
 export function validateRadius(value: string): boolean {
   if (!value) return true;
   return /^\d*\.?\d+(px|rem|em|%)?$/.test(value.trim());

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,308 @@
+import type { CustomThemeColors } from "../store";
+
+export type KofiStyle = "1" | "2" | "3" | "4" | "5" | "6";
+
+let parseCanvas: HTMLCanvasElement | null = null;
+function getParseCtx(): CanvasRenderingContext2D | null {
+  if (!parseCanvas) parseCanvas = document.createElement("canvas");
+  return parseCanvas.getContext("2d");
+}
+
+export function parseColorToRgba(
+  color: string,
+): [number, number, number, number] | null {
+  const ctx = getParseCtx();
+  if (!ctx) return null;
+  ctx.fillStyle = "#000";
+  try {
+    ctx.fillStyle = color;
+  } catch {
+    return null;
+  }
+  const c = ctx.fillStyle;
+  if (typeof c === "string" && c.startsWith("#")) {
+    const hex = c.slice(1);
+    if (hex.length === 6) {
+      const n = parseInt(hex, 16);
+      return [(n >> 16) & 255, (n >> 8) & 255, n & 255, 1];
+    }
+    if (hex.length === 8) {
+      const n = parseInt(hex.slice(0, 6), 16);
+      const a = parseInt(hex.slice(6), 16) / 255;
+      return [(n >> 16) & 255, (n >> 8) & 255, n & 255, a];
+    }
+  }
+  const m = /rgba?\(([^)]+)\)/.exec(c);
+  if (!m) return null;
+  const parts = m[1].split(",").map((s) => parseFloat(s.trim()));
+  if (parts.length < 3 || parts.some((p) => Number.isNaN(p))) return null;
+  return [parts[0], parts[1], parts[2], parts[3] ?? 1];
+}
+
+export function getLuminance(color: string): number {
+  const rgba = parseColorToRgba(color);
+  if (!rgba) return 0.5;
+  const [r, g, b] = rgba;
+  return (r * 0.299 + g * 0.587 + b * 0.114) / 255;
+}
+
+export function isLightColor(color: string): boolean {
+  return getLuminance(color) > 0.5;
+}
+
+export function getAutoKofiStyle(color: string): KofiStyle {
+  const rgba = parseColorToRgba(color);
+  if (!rgba) return "3";
+  const [r8, g8, b8] = rgba;
+  const r = r8 / 255;
+  const g = g8 / 255;
+  const b = b8 / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  const luminance = r * 0.299 + g * 0.587 + b * 0.114;
+  if (max === min) return luminance > 0.5 ? "1" : "3";
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  if (s < 0.15) return luminance > 0.5 ? "1" : "3";
+  let h: number;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
+  else if (max === g) h = ((b - r) / d + 2) * 60;
+  else h = ((r - g) / d + 4) * 60;
+  if (h < 30 || h >= 330) return "6";
+  if (h < 70) return "2";
+  if (h < 165) return luminance > 0.5 ? "1" : "3";
+  if (h < 255) return "5";
+  return "4";
+}
+
+function relativeLuminance(color: string): number {
+  const rgba = parseColorToRgba(color);
+  if (!rgba) return 0.5;
+  const toLin = (v: number) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const [r, g, b] = rgba;
+  return 0.2126 * toLin(r) + 0.7152 * toLin(g) + 0.0722 * toLin(b);
+}
+
+export function getContrastRatio(bg: string, fg: string): number {
+  const L1 = relativeLuminance(bg);
+  const L2 = relativeLuminance(fg);
+  const [a, b] = L1 > L2 ? [L1, L2] : [L2, L1];
+  return (a + 0.05) / (b + 0.05);
+}
+
+export function splitHexAlpha(color: string): { hex6: string; alpha: number } {
+  if (/^#[0-9a-fA-F]{8}$/.test(color)) {
+    return {
+      hex6: color.slice(0, 7).toLowerCase(),
+      alpha: parseInt(color.slice(7), 16) / 255,
+    };
+  }
+  if (/^#[0-9a-fA-F]{6}$/.test(color)) {
+    return { hex6: color.toLowerCase(), alpha: 1 };
+  }
+  if (/^#[0-9a-fA-F]{3}$/.test(color)) {
+    const h = color
+      .slice(1)
+      .split("")
+      .map((c) => c + c)
+      .join("");
+    return { hex6: ("#" + h).toLowerCase(), alpha: 1 };
+  }
+  const rgba = parseColorToRgba(color);
+  if (!rgba) return { hex6: "#121212", alpha: 1 };
+  const [r, g, b, a] = rgba;
+  const hex6 =
+    "#" +
+    [r, g, b]
+      .map((v) => Math.round(v).toString(16).padStart(2, "0"))
+      .join("");
+  return { hex6: hex6.toLowerCase(), alpha: a };
+}
+
+export function combineHexAlpha(hex6: string, alpha: number): string {
+  const clamped = Math.max(0, Math.min(1, alpha));
+  if (clamped >= 0.999) return hex6.toLowerCase();
+  const aa = Math.round(clamped * 255)
+    .toString(16)
+    .padStart(2, "0");
+  return (hex6 + aa).toLowerCase();
+}
+
+export const CUSTOM_THEME_VAR_MAP: ReadonlyArray<
+  [keyof CustomThemeColors, string]
+> = [
+  ["bgBase", "--bg-base"],
+  ["textPrimary", "--text-primary"],
+  ["accentGreen", "--accent-green"],
+  ["accentYellow", "--accent-yellow"],
+  ["accentRed", "--accent-red"],
+  ["bgSurface", "--bg-surface"],
+  ["bgElevated", "--bg-elevated"],
+  ["bgInput", "--bg-input"],
+  ["bgInputOff", "--bg-input-off"],
+  ["border", "--border"],
+  ["borderFocus", "--border-focus"],
+  ["borderSubtle", "--border-subtle"],
+  ["textMuted", "--text-muted"],
+  ["textDim", "--text-dim"],
+  ["radiusSm", "--radius-sm"],
+  ["radiusMd", "--radius-md"],
+  ["radiusLg", "--radius-lg"],
+  ["containerShadow", "--container-shadow"],
+  ["dividerColor", "--divider-color"],
+  ["statusSuccess", "--status-success"],
+  ["statusError", "--status-error"],
+];
+
+export interface ThemePreset {
+  name: string;
+  colors: CustomThemeColors;
+}
+
+export const THEME_PRESETS: ReadonlyArray<ThemePreset> = [
+  {
+    name: "Midnight",
+    colors: {
+      bgBase: "#121212",
+      textPrimary: "#f9fefe",
+      accentGreen: "#19c233bf",
+      accentYellow: "#febc2fbf",
+      accentRed: "#ff726bbf",
+    },
+  },
+  {
+    name: "Dracula",
+    colors: {
+      bgBase: "#282a36",
+      textPrimary: "#f8f8f2",
+      accentGreen: "#50fa7bcc",
+      accentYellow: "#f1fa8ccc",
+      accentRed: "#ff5555cc",
+    },
+  },
+  {
+    name: "Nord",
+    colors: {
+      bgBase: "#2e3440",
+      textPrimary: "#eceff4",
+      accentGreen: "#a3be8ccc",
+      accentYellow: "#ebcb8bcc",
+      accentRed: "#bf616acc",
+    },
+  },
+  {
+    name: "Solarized",
+    colors: {
+      bgBase: "#002b36",
+      textPrimary: "#eee8d5",
+      accentGreen: "#859900cc",
+      accentYellow: "#b58900cc",
+      accentRed: "#dc322fcc",
+    },
+  },
+  {
+    name: "Paper",
+    colors: {
+      bgBase: "#fafafa",
+      textPrimary: "#1a1a1a",
+      accentGreen: "#1b7a32e6",
+      accentYellow: "#b5790ae6",
+      accentRed: "#c0392be6",
+    },
+  },
+  {
+    name: "Monokai",
+    colors: {
+      bgBase: "#272822",
+      textPrimary: "#f8f8f2",
+      accentGreen: "#a6e22ee6",
+      accentYellow: "#e6db74e6",
+      accentRed: "#f92672e6",
+    },
+  },
+  {
+    name: "Catppuccin",
+    colors: {
+      bgBase: "#1e1e2e",
+      textPrimary: "#cdd6f4",
+      accentGreen: "#a6e3a1cc",
+      accentYellow: "#f9e2afcc",
+      accentRed: "#f38ba8cc",
+    },
+  },
+  {
+    name: "Tokyo Night",
+    colors: {
+      bgBase: "#1a1b26",
+      textPrimary: "#c0caf5",
+      accentGreen: "#9ece6acc",
+      accentYellow: "#e0af68cc",
+      accentRed: "#f7768ecc",
+    },
+  },
+  {
+    name: "Gruvbox",
+    colors: {
+      bgBase: "#282828",
+      textPrimary: "#ebdbb2",
+      accentGreen: "#b8bb26cc",
+      accentYellow: "#fabd2fcc",
+      accentRed: "#fb4934cc",
+    },
+  },
+];
+
+export function validateRadius(value: string): boolean {
+  if (!value) return true;
+  return /^\d*\.?\d+(px|rem|em|%)?$/.test(value.trim());
+}
+
+export function sanitizeImportedTheme(
+  raw: unknown,
+): CustomThemeColors | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const isStr = (v: unknown): v is string =>
+    typeof v === "string" && v.trim().length > 0;
+  if (!isStr(r.bgBase) || !isStr(r.textPrimary)) return null;
+  if (!isStr(r.accentGreen) || !isStr(r.accentYellow) || !isStr(r.accentRed))
+    return null;
+
+  const out: CustomThemeColors = {
+    bgBase: r.bgBase,
+    textPrimary: r.textPrimary,
+    accentGreen: r.accentGreen,
+    accentYellow: r.accentYellow,
+    accentRed: r.accentRed,
+  };
+  const optionalKeys: Array<keyof CustomThemeColors> = [
+    "bgSurface",
+    "bgElevated",
+    "bgInput",
+    "bgInputOff",
+    "border",
+    "borderFocus",
+    "borderSubtle",
+    "textMuted",
+    "textDim",
+    "radiusSm",
+    "radiusMd",
+    "radiusLg",
+    "containerShadow",
+    "dividerColor",
+    "statusSuccess",
+    "statusError",
+  ];
+  for (const k of optionalKeys) {
+    const v = r[k];
+    if (isStr(v)) (out as Record<string, string>)[k] = v;
+  }
+  if (["1", "2", "3", "4", "5", "6"].includes(r.kofiStyle as string)) {
+    out.kofiStyle = r.kofiStyle as KofiStyle;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

  Adds a fully customizable theme system with live editing, presets, import/export, and a background image feature with opacity, blur, and panel transparency controls.

 ## Related issue

  N/A

 ## Testing

  - Switched between Dark / Light / Custom themes → UI updates instantly with no regressions
  - Basic mode: changed the 5 core colors → all derived variables update correctly
  - Advanced mode: edited every CSS variable (backgrounds, borders, text, accents, radius, status) → applied live
  - Applied each preset (Midnight, Dracula, Nord, Solarized, Paper, Monokai, Catppuccin, Tokyo Night, Gruvbox) → swatches and UI match
  - Exported theme to JSON and re-imported it → identical result
  - Uploaded a background image → renders behind the UI
  - Opacity (0–100%) and blur (0–10px, 0.1 step) sliders update live
  - Panel opacity slider correctly blends panels with the background image
  - Deleted the original image file → theme still works (base64 persisted)
  - Restarted the app → all custom theme settings preserved
  - Ko-fi button auto / manual style selection works across themes

 ## Screenshots
<img width="983" height="801" alt="{4BA6FCC7-8371-4769-86F4-0E7A329F2BCA}" src="https://github.com/user-attachments/assets/32a06c1b-65f1-4f4c-a8d7-7fdd7bea0417" />
<img width="556" height="639" alt="{B9007C77-F02E-466C-917B-82B7AD1D63C1}" src="https://github.com/user-attachments/assets/d6ce3259-ec3f-4069-a519-0172bb845b18" />

 ## Checklist

  - [x] I tested the change locally
  - [x] I kept the change focused and relevant
  - [x] I updated any related documentation if needed