### PR TITLE
Prevent Chromium Caret Browsing popup on F7

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,16 @@ import App from "./App.tsx";
 // This is to Disable the Right Click Menu
 document.addEventListener("contextmenu", (e) => e.preventDefault());
 
+window.addEventListener(
+  "keydown",
+  (event) => {
+    if (event.key === "F7") {
+      event.preventDefault();
+    }
+  },
+  { capture: true },
+);
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## Summary

Prevented the default browser behavior for the `F7` key in the capture phase so the Caret Browsing popup no longer appears in Chromium/WebView. The application can still handle the `F7` hotkey afterward as intended.

## Related issue

#103

## Testing

Tested locally by running the app and pressing `F7` to verify that the browser popup no longer appears and the hotkey continues to work as expected. Also verified with `npm run build`, which completed successfully.

## Checklist

- [x] I tested the change locally
- [x] I kept the change focused and relevant
- [ ] I updated any related documentation if needed