### PR TITLE
fix: release held mouse button when stopping mid-click

### DIFF
--- a/src-tauri/src/engine/mouse.rs
+++ b/src-tauri/src/engine/mouse.rs
@@ -184,6 +184,36 @@ pub fn send_batch(down: u32, up: u32, n: usize, _hold_ms: u32) {
     };
 }
 
+fn dispatch_click<FSend, FSleep, FActive>(
+    down: u32,
+    up: u32,
+    hold_ms: u32,
+    send_event: &mut FSend,
+    sleep_for: &mut FSleep,
+    is_active: &FActive,
+) -> bool
+where
+    FSend: FnMut(u32),
+    FSleep: FnMut(Duration),
+    FActive: Fn() -> bool,
+{
+    if !is_active() {
+        return false;
+    }
+
+    send_event(down);
+    if hold_ms > 0 {
+        sleep_for(Duration::from_millis(hold_ms as u64));
+        if !is_active() {
+            send_event(up);
+            return false;
+        }
+    }
+
+    send_event(up);
+    true
+}
+
 pub fn send_clicks(
     down: u32,
     up: u32,
@@ -202,19 +232,21 @@ pub fn send_clicks(
         return;
     }
 
+    let is_active = || control.is_active();
+    let mut send_event = |flags| send_mouse_event(flags);
+    let mut sleep_for = |duration| sleep_interruptible(duration, control);
+
     for index in 0..count {
-        if !control.is_active() {
+        if !dispatch_click(
+            down,
+            up,
+            hold_ms,
+            &mut send_event,
+            &mut sleep_for,
+            &is_active,
+        ) {
             return;
         }
-
-        send_mouse_event(down);
-        if hold_ms > 0 {
-            sleep_interruptible(Duration::from_millis(hold_ms as u64), control);
-            if !control.is_active() {
-                return;
-            }
-        }
-        send_mouse_event(up);
 
         if index + 1 < count && use_double_click_gap && double_click_delay_ms > 0 {
             sleep_interruptible(Duration::from_millis(double_click_delay_ms as u64), control);
@@ -288,5 +320,52 @@ pub fn smooth_move(
         if i < steps {
             std::thread::sleep(step_dur);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::{Cell, RefCell};
+
+    use super::dispatch_click;
+
+    #[test]
+    fn dispatch_click_skips_events_when_run_is_already_stopped() {
+        let events = RefCell::new(Vec::new());
+        let mut send_event = |flags| events.borrow_mut().push(flags);
+        let mut sleep_for = |_| {};
+        let is_active = || false;
+
+        let sent = dispatch_click(1, 2, 5, &mut send_event, &mut sleep_for, &is_active);
+
+        assert!(!sent);
+        assert!(events.borrow().is_empty());
+    }
+
+    #[test]
+    fn dispatch_click_releases_button_when_run_stops_during_hold() {
+        let events = RefCell::new(Vec::new());
+        let mut send_event = |flags| events.borrow_mut().push(flags);
+        let active = Cell::new(true);
+        let mut sleep_for = |_| active.set(false);
+        let is_active = || active.get();
+
+        let sent = dispatch_click(1, 2, 5, &mut send_event, &mut sleep_for, &is_active);
+
+        assert!(!sent);
+        assert_eq!(&*events.borrow(), &[1, 2]);
+    }
+
+    #[test]
+    fn dispatch_click_sends_normal_down_and_up_when_run_stays_active() {
+        let events = RefCell::new(Vec::new());
+        let mut send_event = |flags| events.borrow_mut().push(flags);
+        let mut sleep_for = |_| {};
+        let is_active = || true;
+
+        let sent = dispatch_click(1, 2, 5, &mut send_event, &mut sleep_for, &is_active);
+
+        assert!(sent);
+        assert_eq!(&*events.borrow(), &[1, 2]);
     }
 }


### PR DESCRIPTION
## Summary

- guarantee the matching mouse-up event is sent if the clicker stops during a held click
- refactor the single-click dispatch path just enough to cover the stop/release behavior with unit tests
- keep batching and double-click timing behavior unchanged outside the stop edge case

## Related issue(s)

- Fixes #114
- Related: #93

## Change type

- [x] Bug fix
- [ ] Documentation
- [ ] Contributor workflow / CI
- [ ] Refactor
- [ ] Other

## Validation

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml` (passed)
- `npm install --no-package-lock` (passed)
- `npm run lint` (passed)
- `npm run frontend:build` (passed)
- `cargo check --manifest-path src-tauri/Cargo.toml` (passed)
- `cargo test --manifest-path src-tauri/Cargo.toml` (passed)
- `.\\node_modules\\.bin\\tauri.cmd build --no-bundle` (passed)
- `npm exec tauri build -- --no-bundle` ?? built the release app and NSIS bundle, then failed at updater signing because `TAURI_SIGNING_PRIVATE_KEY` is not set in the local environment

## Checklist

- [x] I ran the relevant local validation commands and recorded them above
- [x] I kept the change focused and avoided unrelated refactors
- [ ] I updated related documentation, templates, or contributor guidance when needed