### PR TITLE
fix: keep advanced section titles from wrapping during resize

### DIFF
--- a/src/components/panels/advanced/AdvancedPanel.css
+++ b/src/components/panels/advanced/AdvancedPanel.css
@@ -118,6 +118,9 @@ input[type="number"]::-webkit-outer-spin-button {
   color: var(--text-primary);
   letter-spacing: -0.02em;
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Divider */

--- a/src/components/panels/advanced/shared.tsx
+++ b/src/components/panels/advanced/shared.tsx
@@ -205,7 +205,6 @@ export function InfoIcon({ text }: { text: string }) {
       return;
     }
 
-    updateTooltipPosition();
     const id = window.requestAnimationFrame(updateTooltipPosition);
 
     const handleReposition = () => {


### PR DESCRIPTION
## Summary

- keep advanced panel card titles on a single line so they do not wrap during the transient resize when switching to the Advanced tab
- defer the tooltip reposition state update in `InfoIcon` to the next animation frame so the current repo lint rules pass cleanly

## Related issue(s)

- Fixes #113

## Change type

- [x] Bug fix
- [ ] Documentation
- [ ] Contributor workflow / CI
- [ ] Refactor
- [ ] Other

## Validation

- `npm install` (passed; refreshed dependencies in the worktree so current upstream packages were available locally)
- `npm run lint` (passed)
- `npm run frontend:build` (passed)
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml` (passed)
- `cargo check --locked --manifest-path src-tauri/Cargo.toml` (passed)
- `cargo test --locked --manifest-path src-tauri/Cargo.toml` (passed)
- `npm exec tauri build -- --no-bundle` (partially passed: release app compiled and the NSIS installer was produced, then the build stopped at updater signing because `TAURI_SIGNING_PRIVATE_KEY` is not set in the local environment)

## Checklist

- [x] I ran the relevant local validation commands and recorded them above
- [x] I kept the change focused and avoided unrelated refactors
- [ ] I updated related documentation, templates, or contributor guidance when needed
