### PR TITLE
feat: add corner style setting (rounded/sharp)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -411,6 +411,11 @@ export default function App() {
     document.documentElement.dataset.theme = settings.theme ?? "dark";
   }, [settings.theme]);
 
+  useEffect(() => {
+    document.documentElement.dataset.corners =
+      settings.cornerStyle === "sharp" ? "sharp" : "rounded";
+  }, [settings.cornerStyle]);
+
   const handleTabChange = (nextTab: Tab) => {
     setTab(nextTab);
 

--- a/src/components/TitleBar.css
+++ b/src/components/TitleBar.css
@@ -49,7 +49,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-sm);
   color: var(--text-dim);
   line-height: 0;
   transition: all 0.5s ease;
@@ -130,7 +130,7 @@
   /* Reset */
   background: transparent;
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   
   /* Visuals */

--- a/src/components/panels/Modes.css
+++ b/src/components/panels/Modes.css
@@ -270,7 +270,7 @@ input[type="number"]::-webkit-outer-spin-button {
 .sectioncontainer {
   background: var(--bg-surface);
   border: 2px solid var(--border);
-  border-radius: 0.4375rem;
+  border-radius: var(--radius-section);
   padding: 0.625rem 0.75rem;
   margin-bottom: 0.625rem;
   flex: 1;
@@ -517,7 +517,7 @@ input[type="number"]::-webkit-outer-spin-button {
   gap: 2px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-subtle);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-sm);
   padding: 0.25rem 0.5rem;
   position: relative;
   overflow: hidden;
@@ -536,28 +536,28 @@ input[type="number"]::-webkit-outer-spin-button {
   top: 0px; left: 0px;
   border-right: none;
   border-bottom: none;
-  border-top-left-radius: 0.375rem;
+  border-top-left-radius: var(--radius-sm);
 }
 
 .adv-arc-tr {
   top: 0px; right: 0px;
   border-left: none;
   border-bottom: none;
-  border-top-right-radius: 0.375rem;
+  border-top-right-radius: var(--radius-sm);
 }
 
 .adv-arc-bl {
   bottom: 0px; left: 0px;
   border-right: none;
   border-top: none;
-  border-bottom-left-radius: 0.375rem;
+  border-bottom-left-radius: var(--radius-sm);
 }
 
 .adv-arc-br {
   bottom: 0px; right: 0px;
   border-left: none;
   border-top: none;
-  border-bottom-right-radius: 0.375rem;
+  border-bottom-right-radius: var(--radius-sm);
 }
 
 /* Edge bars for edge stop */
@@ -639,7 +639,7 @@ input[type="number"]::-webkit-outer-spin-button {
   color: var(--text-muted);
   background: var(--bg-surface);
   padding: 0.25rem 0.625rem;
-  border-radius: 1.25rem;
+  border-radius: var(--radius-disabled);
   border: 1px solid var(--border-subtle);
   box-shadow: 0 0.25rem 0.75rem rgba(0,0,0,0.2);
 }

--- a/src/components/panels/SettingsPanel.css
+++ b/src/components/panels/SettingsPanel.css
@@ -9,13 +9,13 @@
 .settings-panel::-webkit-scrollbar {
   width: 0.375rem;
   background: var(--bg-elevated);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-scrollbar);
 }
 
 
 .settings-panel::-webkit-scrollbar-thumb {
   background: var(--text-dim);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-scrollbar-thumb);
 }
 .settings-panel::-webkit-scrollbar-thumb:hover {
   background: #777;
@@ -206,7 +206,7 @@
 .social-icon--kofi {
   width: 114px;
   height: 30px;
-  border-radius: 10px;
+  border-radius: var(--radius-kofi);
   border: 1px solid var(--border-subtle);
 }
 

--- a/src/components/panels/SettingsPanel.tsx
+++ b/src/components/panels/SettingsPanel.tsx
@@ -296,6 +296,27 @@ export default function SettingsPanel({
             ))}
           </div>
         </div>
+        <div className="settings-row">
+          <div className="settings-label-group">
+            <span className="settings-label">Corner Style</span>
+            <span className="settings-sublabel">
+              Switch between rounded and sharp UI corners.
+            </span>
+          </div>
+          <div className="settings-seg-group">
+            {(["Rounded", "Sharp"] as const).map((o) => (
+              <button
+                key={o}
+                className={`settings-seg-btn ${(settings.cornerStyle === "sharp" ? "Sharp" : "Rounded") === o ? "active" : ""}`}
+                onClick={() =>
+                  update({ cornerStyle: o.toLowerCase() as "rounded" | "sharp" })
+                }
+              >
+                {o}
+              </button>
+            ))}
+          </div>
+        </div>
         <div className="settings-divider" />
         <div className="settings-row">
           <div className="settings-label-group">

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,11 @@
   --radius-sm:     0.375rem;
   --radius-md:     0.625rem;
   --radius-lg:     0.875rem;
+  --radius-section: 0.4375rem;
+  --radius-disabled: 1.25rem;
+  --radius-scrollbar: 0.5rem;
+  --radius-scrollbar-thumb: 0.25rem;
+  --radius-kofi: 10px;
 
   --container-shadow: 0 2px 0.5rem rgba(0, 0, 0, 0.3);
 
@@ -43,6 +48,17 @@
   --update-banner-text-bg: hsl(0, 0%, 80%);
   --status-success: hsl(129, 77%, 60%);
   --status-error: hsl(4, 100%, 71%);
+}
+
+[data-corners="sharp"] {
+  --radius-sm: 0;
+  --radius-md: 0;
+  --radius-lg: 0;
+  --radius-section: 0;
+  --radius-disabled: 0;
+  --radius-scrollbar: 0;
+  --radius-scrollbar-thumb: 0;
+  --radius-kofi: 0;
 }
 
 [data-theme="light"] {

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,6 +8,7 @@ export const APP_VERSION = await getVersion();
 export type SavedPanel = "simple" | "advanced";
 export type ExplanationMode = "off" | "text";
 export type Theme = "dark" | "light";
+export type CornerStyle = "rounded" | "sharp";
 
 export interface Settings {
   version: string;
@@ -48,6 +49,7 @@ export interface Settings {
   showStopOverlay: boolean;
   strictHotkeyModifiers: boolean;
   theme: Theme;
+  cornerStyle: CornerStyle;
 }
 
 export interface ClickerStatus {
@@ -102,6 +104,7 @@ export const DEFAULT_SETTINGS: Settings = {
   showStopOverlay: true,
   strictHotkeyModifiers: false,
   theme: "dark",
+  cornerStyle: "rounded",
 };
 
 function sanitizeSavedPanel(value: unknown): SavedPanel {
@@ -235,6 +238,7 @@ function sanitizeSettings(input?: Partial<Settings> | null): Settings {
     explanationMode: sanitizeExplanationMode(saved),
     lastPanel: sanitizeSavedPanel(saved.lastPanel),
     theme: saved.theme === "light" ? "light" : "dark",
+    cornerStyle: saved.cornerStyle === "sharp" ? "sharp" : "rounded",
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a corner style setting for rounded/sharp UI corners. (default: rounded)

## Related issue

Closes https://github.com/Blur009/Blur-AutoClicker/issues/126

## Testing

Full build and install from scratch, then checked every element in every tab to ensure sharp corners were applied consistently. Also tested to ensure settings persist.

<img src="https://i.imgur.com/aaV7swK.png" width="400"> <img src="https://i.imgur.com/KFyu2lS.png" width="400">

The only outlier I found is [the Ko-fi image inside this button](<https://github.com/Blur009/Blur-AutoClicker/blob/f7588be46f560a30d94726252bf111685f7d6628/src/components/panels/SettingsPanel.tsx#L90>), since the asset itself has a rounded background baked in that becomes noticeable when the UI is sharp. A transparent or filled out version would do the trick. 
- Relevant discussion on Discord: [#💡︱suggestions ](https://discord.com/channels/1262651551588286554/1262653752700178474/1495985791648923668)

## Checklist

- [x] I tested the change locally
- [x] I kept the change focused and relevant
- [ ] I updated any related documentation if needed
