### PR TITLE
Fix stop overlay going off-screen on scaled displays

### DIFF
--- a/overlay.html
+++ b/overlay.html
@@ -177,6 +177,12 @@
         }
 
         function addZone(x, y, w, h, cls) {
+            const scale = window.devicePixelRatio || 1;
+            x = x / scale;
+            y = y / scale;
+            w = w / scale;
+            h = h / scale;
+            
             if (w <= 0 || h <= 0) return;
             const div = document.createElement('div');
             div.className = 'zone ' + cls;


### PR DESCRIPTION
## Summary

Fixes a visual issue where the stop overlay became offset and extended off-screen when Windows display scaling was above 100%.

While testing, I found that the backend kept sending the same screen size values, but `overlay.html` was using a smaller drawing area when display scaling was increased. For example, the backend still reported `1920x1200`, while the overlay page reported `1536x960` at 125% scaling and `1280x800` at 150% scaling.

This change divides the overlay coordinates by the display scale before drawing them by using `window.devicePixelRatio` and falling back to `1` when no scaling value is available. This keeps the overlay from drifting off-screen at different scaling values.

### Before fix

<table>
  <tr>
    <td align="center"><strong>100% scaling</strong></td>
    <td align="center"><strong>150% scaling</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/efd1de7a-7502-4d7c-be4e-ffcc84840a13" alt="Before fix at 100% scaling" width="420"></td>
    <td><img src="https://github.com/user-attachments/assets/fcc9f3bc-d39b-4265-92cc-7117c2ff83a9" alt="Before fix at 150% scaling" width="420"></td>
  </tr>
</table>

### After fix

<table>
  <tr>
    <td align="center"><strong>100% scaling</strong></td>
    <td align="center"><strong>150% scaling</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/588e6ee9-7882-446e-9756-8a1fe4e30339" alt="After fix at 100% scaling" width="420"></td>
    <td><img src="https://github.com/user-attachments/assets/79852540-1053-45eb-a10d-aceca07ba6fe" alt="After fix at 150% scaling" width="420"></td>
  </tr>
</table>

## Related issue(s)

Closes #91 

## Change type

- [x] Bug fix
- [ ] Documentation
- [ ] Contributor workflow / CI
- [ ] Refactor
- [ ] Other

## Validation

- `npm run lint`  
  Fails due to an existing unrelated lint error in `src/components/panels/advanced/shared.tsx:208:5`
- `npm run frontend:build`  
  Pass
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`  
  Pass
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`  
  Pass
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`  
  Pass

### Manual testing

- Reproduced on latest `dev`
- Tested on a single-display setup 
- Tested only on `1920x1200`
- Did not test multi-monitor or mixed-DPI setups

## Checklist

- [x] I ran the relevant local validation commands and recorded them above
- [x] I kept the change focused and avoided unrelated refactors
- [ ] I updated related documentation, templates, or contributor guidance when needed
