### PR TITLE
Fix run stats persistence after manual stop

### DIFF
--- a/src-tauri/src/engine/stats.rs
+++ b/src-tauri/src/engine/stats.rs
@@ -4,8 +4,6 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-// TODO: Stats are broken. I'm guessing I accidentally removed some kind of trigger for it to actually write it but i am not sure. I haven't looked into it but it needs to get fixed before 3.5
-
 static STATS_LOCK: Mutex<()> = Mutex::new(());
 
 const MAX_NORMAL_RUNS: usize = 100;

--- a/src-tauri/src/engine/worker.rs
+++ b/src-tauri/src/engine/worker.rs
@@ -118,6 +118,10 @@ pub fn start_clicker_inner(app: &AppHandle) -> Result<ClickerStatusPayload, Stri
 
     std::thread::spawn(move || {
         let outcome = engine_start(config, control.clone());
+
+        print_run_stats(outcome.click_count, outcome.elapsed_secs, outcome.avg_cpu);
+        record_run(outcome.click_count, outcome.elapsed_secs, outcome.avg_cpu);
+
         if !control.is_current_generation() {
             return;
         }
@@ -125,10 +129,6 @@ pub fn start_clicker_inner(app: &AppHandle) -> Result<ClickerStatusPayload, Stri
         let state = app_handle.state::<ClickerState>();
         state.running.store(false, Ordering::SeqCst);
         state.active_sequence_index.store(-1, Ordering::SeqCst);
-
-        print_run_stats(outcome.click_count, outcome.elapsed_secs, outcome.avg_cpu);
-
-        record_run(outcome.click_count, outcome.elapsed_secs, outcome.avg_cpu);
 
         *state.stop_reason.lock().unwrap() = Some(outcome.stop_reason.clone());
         *state.last_error.lock().unwrap() = None;
@@ -414,7 +414,8 @@ pub fn start_clicker(config: ClickerConfig, control: RunControl) -> RunOutcome {
             }
         }
 
-        let per_tick_clicks = batch_size.saturating_mul(if config.double_click_enabled { 2 } else { 1 });
+        let per_tick_clicks =
+            batch_size.saturating_mul(if config.double_click_enabled { 2 } else { 1 });
         let requested_clicks = if config.sequence_enabled && !config.sequence_points.is_empty() {
             sequence_clicks_remaining.min(per_tick_clicks)
         } else {


### PR DESCRIPTION
## Summary

This fixes usage stats not being saved when a clicker run is stopped manually. The run summary is now logged and persisted immediately after the engine loop exits, before stale generation checks can return early after a stop/start transition.

The completed TODO about broken stats was removed.

## Related issue

N/A.

## Testing

- Ran `cargo fmt --check`
- Ran `git diff --check`
- Attempted `cargo test`, but it could not run on macOS because upstream `dev` currently depends on `winreg` outside a Windows-only target dependency block.

## Checklist

- [ ] I tested the change locally
- [x] I kept the change focused and relevant
- [ ] I updated any related documentation if needed