### PR TITLE
fix: move cadence summary to rate input

### DIFF
--- a/src-tauri/src/engine/worker.rs
+++ b/src-tauri/src/engine/worker.rs
@@ -414,7 +414,8 @@ pub fn start_clicker(config: ClickerConfig, control: RunControl) -> RunOutcome {
             }
         }
 
-        let per_tick_clicks = batch_size.saturating_mul(if config.double_click_enabled { 2 } else { 1 });
+        let per_tick_clicks =
+            batch_size.saturating_mul(if config.double_click_enabled { 2 } else { 1 });
         let requested_clicks = if config.sequence_enabled && !config.sequence_points.is_empty() {
             sequence_clicks_remaining.min(per_tick_clicks)
         } else {

--- a/src/cadence.ts
+++ b/src/cadence.ts
@@ -56,6 +56,32 @@ export function getMaxDoubleClickDelayMs(settings: CadenceSettings): number {
   return cps > 0 ? Math.max(20, Math.floor(1000 / cps) - 2) : 9999;
 }
 
+export function formatMillisecondsSummary(totalMs: number): string {
+  const roundedMs = Math.max(1, Math.round(totalMs));
+  const hours = Math.floor(roundedMs / 3_600_000);
+  const remainderAfterHours = roundedMs % 3_600_000;
+  const minutes = Math.floor(remainderAfterHours / 60_000);
+  const remainderAfterMinutes = remainderAfterHours % 60_000;
+  const seconds = Math.floor(remainderAfterMinutes / 1_000);
+  const milliseconds = remainderAfterMinutes % 1_000;
+  const parts: string[] = [];
+
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0) {
+    parts.push(`${minutes}m`);
+  }
+  if (seconds > 0) {
+    parts.push(`${seconds}s`);
+  }
+  if (milliseconds > 0 || parts.length === 0) {
+    parts.push(`${milliseconds}ms`);
+  }
+
+  return parts.join(" ");
+}
+
 export function formatDurationSummary(settings: CadenceSettings): string {
   const parts: string[] = [];
 

--- a/src/components/CadenceInput.tsx
+++ b/src/components/CadenceInput.tsx
@@ -1,6 +1,10 @@
 import type { ChangeEvent, CSSProperties, FocusEvent, WheelEvent } from "react";
 import "./panels/advanced/AdvancedPanel.css";
-import { RATE_INPUT_MODE_OPTIONS } from "../cadence";
+import {
+  formatMillisecondsSummary,
+  getEffectiveIntervalMs,
+  RATE_INPUT_MODE_OPTIONS,
+} from "../cadence";
 import { normalizeIntegerRaw } from "../numberInput";
 import type { RateInputMode, Settings } from "../store";
 import { useTranslation } from "../i18n";
@@ -352,6 +356,9 @@ export default function CadenceInput({ settings, update, variant }: Props) {
       ))}
     </div>
   );
+  const rateCadenceDisplay = `${formatMillisecondsSummary(
+    getEffectiveIntervalMs(settings),
+  )} ${t("advanced.delay")}`;
 
   return (
     <div className="adv-cadence-block">
@@ -531,6 +538,11 @@ export default function CadenceInput({ settings, update, variant }: Props) {
         </div>
         {modeToggle}
       </div>
+      {settings.rateInputMode === "rate" ? (
+        <div className="adv-cadence-summary-row">
+          <span className="adv-cadence-summary">{rateCadenceDisplay}</span>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/panels/advanced/AdvancedPanel.css
+++ b/src/components/panels/advanced/AdvancedPanel.css
@@ -152,6 +152,19 @@ input[type="number"]::-webkit-outer-spin-button {
   flex-wrap: wrap;
 }
 
+.adv-cadence-summary-row {
+  display: flex;
+  align-items: center;
+  min-height: 1rem;
+}
+
+.adv-cadence-summary {
+  color: var(--text-dim);
+  font-family: 'DMSans', sans-serif;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-md);
+}
+
 .adv-axis-label {
   margin-left: 0;
   margin-right: 0.25rem;
@@ -214,6 +227,10 @@ input[type="number"]::-webkit-outer-spin-button {
   font-size: 0.875rem;
   font-weight: var(--font-weight-hv);
   color: var(--text-primary);
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 0;
 }
 
 .adv-unit {

--- a/src/components/panels/advanced/LimitsSection.tsx
+++ b/src/components/panels/advanced/LimitsSection.tsx
@@ -22,19 +22,28 @@ export default function LimitsSection({ settings, update, showInfo }: Props) {
   );
 
   useEffect(() => {
+    let nextMode: "clicks" | "time" | null = null;
+
     if (
       settings.timeLimitEnabled &&
       !settings.clickLimitEnabled &&
       mode !== "time"
     ) {
-      setMode("time");
+      nextMode = "time";
     } else if (
       settings.clickLimitEnabled &&
       !settings.timeLimitEnabled &&
       mode !== "clicks"
     ) {
-      setMode("clicks");
+      nextMode = "clicks";
     }
+
+    if (nextMode === null) {
+      return;
+    }
+
+    const id = window.requestAnimationFrame(() => setMode(nextMode));
+    return () => window.cancelAnimationFrame(id);
   }, [settings.clickLimitEnabled, settings.timeLimitEnabled, mode]);
 
   useEffect(() => {

--- a/src/components/panels/advanced/shared.tsx
+++ b/src/components/panels/advanced/shared.tsx
@@ -224,7 +224,6 @@ export function InfoIcon({ text }: { text: string }) {
       return;
     }
 
-    updateTooltipPosition();
     const id = window.requestAnimationFrame(updateTooltipPosition);
 
     const handleReposition = () => {


### PR DESCRIPTION
## Summary

- show the derived delay/cadence summary only while the Advanced cadence control is in Rate mode
- keep Delay mode focused on the editable duration inputs without the extra cadence summary
- make Advanced numeric cadence inputs transparent so browser default white input boxes do not show through
- include minimal upstream validation hygiene fixes for the existing lint and Rust format failures on current dev

## Related issue(s)

N/A

## Change type

- [x] Bug fix
- [ ] Documentation
- [ ] Contributor workflow / CI
- [ ] Refactor
- [ ] Other

## Validation

- npm install passed; dependency install only, lockfile churn was discarded
- npm run lint failed initially on existing upstream React lint errors, then passed after minimal fixes
- npm run frontend:build passed; initial sandbox run hit Vite spawn permissions, rerun with normal permissions passed
- cargo fmt check failed initially on existing upstream formatting, then passed after cargo fmt
- cargo check locked passed
- cargo test locked passed; 15 tests passed
- Tauri no-bundle build passed and built the release executable

## Checklist

- [x] I ran the relevant local validation commands and recorded them above
- [x] I kept the change focused and avoided unrelated refactors
- [x] I updated related documentation, templates, or contributor guidance when needed
