### PR TITLE
fix: move winreg to windows target dependencies

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ tauri-plugin-log = "2.0"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-store = "2"
 tauri-plugin-global-shortcut = "2"
-log = "0.4"              
+log = "0.4"
 serde_json = "1.0"
 raw-window-handle = "0.6.2"
 tauri-plugin-updater = "2.10.0"
@@ -34,6 +34,8 @@ sha2 = "0.10"
 hex = "0.4"
 dirs = "6.0.0"
 windows-targets = "0.48"
+
+[target.'cfg(windows)'.dependencies]
 winreg = "0.52"
 
 [profile.release]


### PR DESCRIPTION
## Summary

Moves `winreg` from the general Rust dependencies to a Windows-only target dependency block.

This keeps the Windows Registry dependency available for Windows builds, while avoiding unnecessary `winreg` builds on non-Windows targets.

## Testing

- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- Ran `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- Ran `cargo test --manifest-path src-tauri/Cargo.toml --locked`

Result: all Rust tests passed.