### PR TITLE
feat: Add single-instance enforcement with tauri-plugin-single-instance

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tokio",
@@ -4617,6 +4618,21 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 reqwest = { version = "0.12", features = ["json"] }
 tauri-plugin-opener = "2.0"
+tauri-plugin-single-instance = "2"
 tauri-plugin-log = "2.0"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-store = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,14 @@ const STATUS_EVENT: &str = "clicker-status";
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            if !argv.iter().any(|a| a == "--autostart") {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            }
+        }))
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init())


### PR DESCRIPTION
## Summary

Adds single-instance enforcement using `tauri-plugin-single-instance` v2.4.2. When "Minimize to Tray" is enabled, reopening the app from the taskbar or Start Menu now brings the existing tray instance to the foreground instead of spawning a new process with its own tray icon. The plugin uses an OS-level named mutex to detect subsequent launches and triggers a callback on the first instance to show and focus the main window. Autostart launches skip the window show behavior to preserve background startup functionality.

## Related issue(s)

https://github.com/Blur009/Blur-AutoClicker/issues/174

## Change type

- [x] Bug fix
- [ ] Documentation
- [ ] Contributor workflow / CI
- [ ] Refactor
- [ ] Other

## Validation

npm run lint
- No output (no lint errors)

npm run frontend:build
- Built in 111ms, 0 errors

cargo fmt --manifest-path src-tauri/Cargo.toml --check
- No output (formatting clean)

cargo check --manifest-path src-tauri/Cargo.toml --locked
- Finished in 44.06s

cargo test --manifest-path src-tauri/Cargo.toml --locked
- 15 passed; 0 failed

## Checklist

- [x] I ran the relevant local validation commands and recorded them above
- [x] I kept the change focused and avoided unrelated refactors
- [x] I updated related documentation, templates, or contributor guidance when needed