### PR TITLE
fix: persist sequence-clicking points in saved profiles

### DIFF
--- a/src/settingsSchema.ts
+++ b/src/settingsSchema.ts
@@ -49,6 +49,8 @@ export interface PresetSnapshot {
   edgeStopBottom: number;
   edgeStopLeft: number;
   edgeStopRight: number;
+  sequenceEnabled: boolean;
+  sequencePoints: SequencePoint[];
 }
 
 export interface PresetDefinition {
@@ -68,8 +70,6 @@ export interface Settings extends PresetSnapshot {
   durationMinutes: number;
   durationSeconds: number;
   durationMilliseconds: number;
-  sequenceEnabled: boolean;
-  sequencePoints: SequencePoint[];
   customStopZoneEnabled: boolean;
   customStopZoneX: number;
   customStopZoneY: number;
@@ -148,6 +148,8 @@ export const PRESET_SNAPSHOT_KEYS = [
   "edgeStopBottom",
   "edgeStopLeft",
   "edgeStopRight",
+  "sequenceEnabled",
+  "sequencePoints",
 ] as const satisfies ReadonlyArray<keyof PresetSnapshot>;
 
 export function clampNumber(
@@ -279,6 +281,8 @@ export function buildPresetSnapshot(settings: Settings): PresetSnapshot {
     edgeStopBottom: settings.edgeStopBottom,
     edgeStopLeft: settings.edgeStopLeft,
     edgeStopRight: settings.edgeStopRight,
+    sequenceEnabled: settings.sequenceEnabled,
+    sequencePoints: settings.sequencePoints,
   };
 }
 
@@ -444,6 +448,11 @@ function sanitizePresetSnapshot(
       SETTINGS_LIMITS.stopBoundary.min,
       SETTINGS_LIMITS.stopBoundary.max,
     ),
+    sequenceEnabled: sanitizeBoolean(
+      saved.sequenceEnabled,
+      defaults.sequenceEnabled,
+    ),
+    sequencePoints: sanitizeSequencePoints(saved.sequencePoints),
   };
 }
 


### PR DESCRIPTION
# fix: persist sequence-clicking points in saved profiles

## Summary

Closes #182.

`PresetSnapshot` — the typed subset of `Settings` that gets serialized into a saved preset — was missing `sequenceEnabled` and `sequencePoints`. As a result `buildPresetSnapshot` silently dropped the user's sequence configuration on save, and `applyPresetSnapshot` had nothing to restore on switch, so re-applying a profile left whatever sequence points happened to be in the live store untouched. The Rust side already round-trips both fields correctly; the gap was purely in the TypeScript preset schema.

## Why

Sequence points are operational settings — a profile that doesn't carry them isn't a profile of the clicker, and switching profiles silently keeps stale data. The reporter explicitly called this out in #182 ("saving these settings has not even been attempted yet").

## What changed

All edits are in `src/settingsSchema.ts`:

- Added `sequenceEnabled: boolean` and `sequencePoints: SequencePoint[]` to `PresetSnapshot`. Removed the now-redundant duplicate declarations from the `Settings` extension (it already inherits them via `extends PresetSnapshot`).
- Added `"sequenceEnabled"` and `"sequencePoints"` to `PRESET_SNAPSHOT_KEYS`. This also flows through to `App.tsx`'s `OPERATIONAL_SETTING_KEYS` (built from `Object.keys(buildPresetSnapshot(DEFAULT_SETTINGS))`), so editing sequence state now correctly clears the active preset, matching the behavior of every other operational setting.
- Added the two fields to the object returned by `buildPresetSnapshot`.
- Added sanitization for them in `sanitizePresetSnapshot`, reusing the existing `sanitizeSequencePoints` and `sanitizeBoolean` helpers.

`applyPresetSnapshot`, `createPresetDefinition`, `handleApplyPreset`, and the Rust backend needed no changes — they all already operate on the full snapshot and pick up the new keys for free.

## Test plan

- [x] `npx tsc -b` — clean (no type errors in any consumer of `PresetSnapshot`/`Settings`).
- [x] Manual round-trip on Windows: configure sequence points → Save Profile A → clear points → Save Profile B → switch to A → verify points restored → switch to B → verify points cleared.
- [x] Existing presets persisted before this PR keep working (sanitizer falls back to defaults for the missing keys).