### PR TITLE
fix: prevent duplicate tray instances (#174)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-build = { version = "2.0", features = [] }
 
 [dependencies]
 tauri = { version = "2.0", features = ["tray-icon", "image-ico"] }
-windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_Graphics_Dwm", "Win32_Graphics_Gdi", "Win32_UI_HiDpi"] }
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_Security", "Win32_Graphics_Dwm", "Win32_Graphics_Gdi", "Win32_UI_HiDpi"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod engine;
 mod hotkeys;
 mod overlay;
 mod sequence_picker;
+mod single_instance;
 mod ui_commands;
 mod updates;
 
@@ -25,6 +26,11 @@ const STATUS_EVENT: &str = "clicker-status";
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let _single_instance_guard = match single_instance::acquire() {
+        Some(guard) => guard,
+        None => return,
+    };
+
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -63,7 +63,6 @@ mod platform {
     fn wide_null(value: &str) -> Vec<u16> {
         value.encode_utf16().chain(std::iter::once(0)).collect()
     }
-
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -1,0 +1,95 @@
+#[cfg(target_os = "windows")]
+mod platform {
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, ERROR_ALREADY_EXISTS, HANDLE};
+    use windows_sys::Win32::System::Threading::CreateMutexW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        FindWindowW, SetForegroundWindow, ShowWindow, SW_RESTORE,
+    };
+
+    const MUTEX_NAME: &str = r"Local\BlurAutoClicker.SingleInstance";
+    const MAIN_WINDOW_TITLE: &str = "BlurAutoClicker";
+
+    pub struct SingleInstanceGuard {
+        mutex: HANDLE,
+    }
+
+    pub fn acquire() -> Option<SingleInstanceGuard> {
+        acquire_named(MUTEX_NAME, MAIN_WINDOW_TITLE)
+    }
+
+    fn acquire_named(mutex_name: &str, window_title: &str) -> Option<SingleInstanceGuard> {
+        let mutex_name = wide_null(mutex_name);
+        let mutex = unsafe { CreateMutexW(std::ptr::null(), 0, mutex_name.as_ptr()) };
+
+        if mutex == 0 {
+            return Some(SingleInstanceGuard { mutex });
+        }
+
+        if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+            activate_existing_instance(window_title);
+            unsafe {
+                CloseHandle(mutex);
+            }
+            return None;
+        }
+
+        Some(SingleInstanceGuard { mutex })
+    }
+
+    impl Drop for SingleInstanceGuard {
+        fn drop(&mut self) {
+            if self.mutex != 0 {
+                unsafe {
+                    CloseHandle(self.mutex);
+                }
+            }
+        }
+    }
+
+    fn activate_existing_instance(window_title: &str) {
+        let title = wide_null(window_title);
+        let hwnd = unsafe { FindWindowW(std::ptr::null(), title.as_ptr()) };
+
+        if hwnd == 0 {
+            return;
+        }
+
+        unsafe {
+            ShowWindow(hwnd, SW_RESTORE);
+            SetForegroundWindow(hwnd);
+        }
+    }
+
+    fn wide_null(value: &str) -> Vec<u16> {
+        value.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::acquire_named;
+
+        #[test]
+        fn second_acquire_returns_none_while_mutex_exists() {
+            let mutex_name = format!(
+                r"Local\BlurAutoClicker.SingleInstance.Test.{}",
+                std::process::id()
+            );
+
+            let _guard =
+                acquire_named(&mutex_name, "BlurAutoClicker Test Window").expect("first acquire");
+
+            assert!(acquire_named(&mutex_name, "BlurAutoClicker Test Window").is_none());
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod platform {
+    pub struct SingleInstanceGuard;
+
+    pub fn acquire() -> Option<SingleInstanceGuard> {
+        Some(SingleInstanceGuard)
+    }
+}
+
+pub use platform::acquire;

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -64,23 +64,6 @@ mod platform {
         value.encode_utf16().chain(std::iter::once(0)).collect()
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::acquire_named;
-
-        #[test]
-        fn second_acquire_returns_none_while_mutex_exists() {
-            let mutex_name = format!(
-                r"Local\BlurAutoClicker.SingleInstance.Test.{}",
-                std::process::id()
-            );
-
-            let _guard =
-                acquire_named(&mutex_name, "BlurAutoClicker Test Window").expect("first acquire");
-
-            assert!(acquire_named(&mutex_name, "BlurAutoClicker Test Window").is_none());
-        }
-    }
 }
 
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary
Relaunching BlurAutoClicker now reuses the running Windows instance instead of starting another tray process. Startup acquires a named Windows mutex before Tauri creates tray icons or starts the hotkey listener; duplicate launches restore/focus the existing window and exit.

This prevents duplicate tray icons when Minimize to Tray leaves the original app hidden. It should also remove the likely stale-hotkey path because repeated launches can no longer leave multiple hidden hotkey listeners alive, but #194 remains related until that intermittent report is reproduced and verified.

Fixes #174
Related #194

## Test Plan
- `cargo check`
- `cargo test` (37 passed, including duplicate mutex acquisition coverage)