### PR TITLE
fix: remove light theme font weight overrides

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -76,10 +76,6 @@
 
   --container-shadow: none;
 
-  --font-weight-li: 400;
-  --font-weight-md: 600;
-  --font-weight-hv: 800;
-
   --divider-color: rgba(0, 0, 0, 0.18);
 
   --update-banner-bg: rgba(254, 188, 46, 0.747);


### PR DESCRIPTION
## Summary
- remove light theme font-weight overrides so light mode inherits the base weights
- keep dark and light theme text sizing consistent

Closes #139

## Test
- Verified remote diff changes only src/index.css