### PR TITLE
Add session timer and stopwatch

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -21,6 +21,8 @@ pub struct ClickerState {
     pub settings_initialized: AtomicBool,
     pub paused: Arc<AtomicBool>,
     pub warning: Mutex<Option<String>>,
+    pub session_started_at_ms: AtomicU64,
+    pub last_session_duration_ms: AtomicU64,
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -34,6 +36,8 @@ pub struct ClickerStatusPayload {
     pub warning: Option<String>,
     pub active_sequence_index: Option<usize>,
     pub active_sequence_tick: u64,
+    pub session_started_at_ms: Option<u64>,
+    pub last_session_duration_ms: u64,
 }
 
 #[derive(Clone, serde::Serialize)]

--- a/src-tauri/src/engine/worker.rs
+++ b/src-tauri/src/engine/worker.rs
@@ -169,6 +169,9 @@ pub fn start_clicker_inner(app: &AppHandle) -> Result<ClickerStatusPayload, Stri
         state.active_sequence_tick.store(0, Ordering::SeqCst);
     }
     let expected_generation = state.run_generation.fetch_add(1, Ordering::SeqCst) + 1;
+    state
+        .session_started_at_ms
+        .store(now_epoch_ms(), Ordering::SeqCst);
     state.running.store(true, Ordering::SeqCst);
     let control = RunControl::new(app.clone(), expected_generation);
     let app_handle = app.clone();
@@ -189,6 +192,11 @@ pub fn start_clicker_inner(app: &AppHandle) -> Result<ClickerStatusPayload, Stri
         state.running.store(false, Ordering::SeqCst);
         state.active_sequence_index.store(-1, Ordering::SeqCst);
         state.active_sequence_tick.store(0, Ordering::SeqCst);
+        state.session_started_at_ms.store(0, Ordering::SeqCst);
+        state.last_session_duration_ms.store(
+            (outcome.elapsed_secs.max(0.0) * 1000.0).round() as u64,
+            Ordering::SeqCst,
+        );
 
         *state.stop_reason.lock().unwrap() = Some(outcome.stop_reason.clone());
         *state.last_error.lock().unwrap() = None;
@@ -207,6 +215,13 @@ pub fn stop_clicker_inner(
     state.running.store(false, Ordering::SeqCst);
     state.active_sequence_index.store(-1, Ordering::SeqCst);
     state.active_sequence_tick.store(0, Ordering::SeqCst);
+    let started_at_ms = state.session_started_at_ms.swap(0, Ordering::SeqCst);
+    if started_at_ms > 0 {
+        state.last_session_duration_ms.store(
+            now_epoch_ms().saturating_sub(started_at_ms),
+            Ordering::SeqCst,
+        );
+    }
     state.run_generation.fetch_add(1, Ordering::SeqCst);
     if let Some(reason) = stop_reason {
         *state.stop_reason.lock().unwrap() = Some(reason);
@@ -372,6 +387,7 @@ pub fn current_status(app: &AppHandle) -> ClickerStatusPayload {
     let warning = state.warning.lock().unwrap().clone();
     let active_sequence_index = state.active_sequence_index.load(Ordering::SeqCst);
     let active_sequence_tick = state.active_sequence_tick.load(Ordering::SeqCst);
+    let session_started_at_ms = state.session_started_at_ms.load(Ordering::SeqCst);
 
     ClickerStatusPayload {
         running: state.running.load(Ordering::SeqCst),
@@ -386,6 +402,12 @@ pub fn current_status(app: &AppHandle) -> ClickerStatusPayload {
             None
         },
         active_sequence_tick,
+        session_started_at_ms: if session_started_at_ms > 0 {
+            Some(session_started_at_ms)
+        } else {
+            None
+        },
+        last_session_duration_ms: state.last_session_duration_ms.load(Ordering::SeqCst),
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,8 @@ pub fn run() {
             settings_initialized: AtomicBool::new(false),
             paused: Arc::new(AtomicBool::new(false)),
             warning: Mutex::new(None),
+            session_started_at_ms: AtomicU64::new(0),
+            last_session_duration_ms: AtomicU64::new(0),
         })
         .setup(|app| {
             if cfg!(debug_assertions) {
@@ -160,6 +162,7 @@ pub fn run() {
             ui_commands::get_text_scale_factor,
             ui_commands::start_clicker,
             ui_commands::stop_clicker,
+            ui_commands::stop_clicker_with_reason,
             ui_commands::toggle_clicker,
             ui_commands::update_settings,
             ui_commands::get_settings,

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -107,7 +107,7 @@ pub struct ClickerSettings {
 
 // Frontend-only settings intentionally omitted from Rust:
 // language, minimizeToTray, theme, advancedSequenceLayout, alwaysOnTop,
-// accentColor, presets, activePresetId.
+// accentColor, presets, activePresetId, timer/stopwatch UI preferences.
 
 impl Default for ClickerSettings {
     fn default() -> Self {

--- a/src-tauri/src/ui_commands.rs
+++ b/src-tauri/src/ui_commands.rs
@@ -56,6 +56,14 @@ pub fn stop_clicker(app: AppHandle) -> Result<ClickerStatusPayload, String> {
 }
 
 #[tauri::command]
+pub fn stop_clicker_with_reason(
+    app: AppHandle,
+    reason: String,
+) -> Result<ClickerStatusPayload, String> {
+    stop_clicker_inner(&app, Some(reason))
+}
+
+#[tauri::command]
 pub fn toggle_clicker(app: AppHandle) -> Result<ClickerStatusPayload, String> {
     let state = app.state::<ClickerState>();
     if state.running.load(Ordering::SeqCst) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   useState,
 } from "react";
 import { applyAccentTheme } from "./accentTheme";
+import TimerWidget from "./components/TimerWidget";
 import UpdateBanner from "./components/Updatebanner";
 import { canonicalizeHotkeyForBackend } from "./hotkeys";
 
@@ -35,6 +36,7 @@ import {
   loadSettings,
   saveSettings,
 } from "./store";
+import { timeLimitDurationMs, timeLimitStopReason } from "./timerUtils";
 
 const SimplePanel = lazy(() => import("./components/panels/SimplePanel"));
 const AdvancedPanel = lazy(
@@ -60,17 +62,19 @@ function getPanelSize(
   tab: Tab,
   hasUpdate: boolean,
   advancedSequenceLayout: Settings["advancedSequenceLayout"],
+  showTimerWidget: boolean,
 ) {
   const extra = hasUpdate ? 30 : 0;
+  const timerExtra = tab !== "settings" && showTimerWidget ? 74 : 0;
   if (tab === "simple") {
-    return { width: 650, height: 175 + extra };
+    return { width: 650, height: 175 + extra + timerExtra };
   }
   if (tab === "settings") return { width: 560, height: 720 + extra };
-  if (tab === "zones") return { width: 750, height: 720 + extra };
+  if (tab === "zones") return { width: 750, height: 720 + extra + timerExtra };
   if (advancedSequenceLayout === "tall") {
-    return { width: 560, height: 720 + extra };
+    return { width: 560, height: 720 + extra + timerExtra };
   }
-  return { width: 912, height: 527 + extra };
+  return { width: 912, height: 527 + extra + timerExtra };
 }
 
 const textScale = await invoke<number>("get_text_scale_factor");
@@ -110,6 +114,8 @@ const DEFAULT_STATUS: ClickerStatus = {
   warning: null,
   activeSequenceIndex: null,
   activeSequenceTick: 0,
+  sessionStartedAtMs: null,
+  lastSessionDurationMs: 0,
 };
 
 const DEFAULT_APP_INFO: AppInfo = {
@@ -120,6 +126,18 @@ const DEFAULT_APP_INFO: AppInfo = {
 
 type UpdateSettingsOptions = {
   preserveActivePreset?: boolean;
+};
+
+type StopwatchState = {
+  elapsedMs: number;
+  startedAtMs: number | null;
+  running: boolean;
+};
+
+const DEFAULT_STOPWATCH_STATE: StopwatchState = {
+  elapsedMs: 0,
+  startedAtMs: null,
+  running: false,
 };
 
 async function syncSettingsToBackend(settings: Settings) {
@@ -160,6 +178,10 @@ export default function App() {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [status, setStatus] = useState<ClickerStatus>(DEFAULT_STATUS);
+  const [stopwatch, setStopwatch] = useState<StopwatchState>(
+    DEFAULT_STOPWATCH_STATE,
+  );
+  const [clockNowMs, setClockNowMs] = useState(() => Date.now());
   const [appInfo, setAppInfo] = useState<AppInfo>(DEFAULT_APP_INFO);
   const [updateInfo, setUpdateInfo] = useState<{
     currentVersion: string;
@@ -180,6 +202,9 @@ export default function App() {
   const resizeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const toggleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sessionStartedAtRef = useRef<number | null>(null);
+  const previousRunningRef = useRef(false);
+  const pendingLastSessionDurationRef = useRef<number | null>(null);
 
   const setUiSettings = (nextSettings: Settings) => {
     uiSettingsRef.current = nextSettings;
@@ -326,6 +351,34 @@ export default function App() {
     },
     [],
   );
+
+  const handleStopwatchToggle = useCallback(() => {
+    const now = Date.now();
+    setClockNowMs(now);
+    setStopwatch((current) => {
+      if (current.running) {
+        const elapsedFromRun = current.startedAtMs
+          ? now - current.startedAtMs
+          : 0;
+        return {
+          elapsedMs: current.elapsedMs + elapsedFromRun,
+          startedAtMs: null,
+          running: false,
+        };
+      }
+
+      return {
+        ...current,
+        startedAtMs: now,
+        running: true,
+      };
+    });
+  }, []);
+
+  const handleStopwatchReset = useCallback(() => {
+    setClockNowMs(Date.now());
+    setStopwatch(DEFAULT_STOPWATCH_STATE);
+  }, []);
 
   const applyStartupWindowPlacement = async () => {
     await getCurrentWindow().center();
@@ -623,6 +676,104 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    if (!status.running && !stopwatch.running) {
+      return;
+    }
+
+    const refreshClock = () => setClockNowMs(Date.now());
+    refreshClock();
+    const interval = window.setInterval(refreshClock, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [status.running, stopwatch.running]);
+
+  useEffect(() => {
+    const saveLastSessionDuration = (durationMs: number) => {
+      if (
+        durationMs > 0 &&
+        committedSettingsRef.current.lastSessionDurationMs !== durationMs
+      ) {
+        updateSettings(
+          { lastSessionDurationMs: durationMs },
+          { preserveActivePreset: true },
+        );
+      }
+    };
+
+    if (status.running && status.sessionStartedAtMs) {
+      sessionStartedAtRef.current = status.sessionStartedAtMs;
+    }
+
+    if (previousRunningRef.current && !status.running) {
+      const fallbackDurationMs = sessionStartedAtRef.current
+        ? Date.now() - sessionStartedAtRef.current
+        : 0;
+      const durationMs = Math.max(
+        0,
+        Math.round(status.lastSessionDurationMs || fallbackDurationMs),
+      );
+
+      if (settingsLoaded) {
+        saveLastSessionDuration(durationMs);
+      } else {
+        pendingLastSessionDurationRef.current = durationMs;
+      }
+
+      sessionStartedAtRef.current = null;
+    }
+
+    if (
+      settingsLoaded &&
+      !status.running &&
+      pendingLastSessionDurationRef.current !== null
+    ) {
+      saveLastSessionDuration(pendingLastSessionDurationRef.current);
+      pendingLastSessionDurationRef.current = null;
+    }
+
+    previousRunningRef.current = status.running;
+  }, [settingsLoaded, status, updateSettings]);
+
+  useEffect(() => {
+    if (
+      !settings.timeLimitEnabled ||
+      !status.running ||
+      !status.sessionStartedAtMs
+    ) {
+      return;
+    }
+
+    const durationMs = timeLimitDurationMs(settings);
+    if (durationMs <= 0) {
+      return;
+    }
+
+    const stopAtMs = status.sessionStartedAtMs + durationMs;
+    const stop = () => {
+      invoke<ClickerStatus>("stop_clicker_with_reason", {
+        reason: timeLimitStopReason(durationMs),
+      })
+        .then(setStatus)
+        .catch((err) => {
+          console.error("Failed to stop clicker after countdown:", err);
+        });
+    };
+
+    const remainingMs = stopAtMs - Date.now();
+    if (remainingMs <= 0) {
+      stop();
+      return;
+    }
+
+    const timeout = window.setTimeout(
+      stop,
+      Math.min(remainingMs, 2_147_483_647),
+    );
+
+    return () => window.clearTimeout(timeout);
+  }, [settings, status.running, status.sessionStartedAtMs]);
+
+  useEffect(() => {
     const handleDropdownOverflow = (event: Event) => {
       const { active, bottom = 0 } = (
         event as CustomEvent<DropdownOverflowDetail>
@@ -665,6 +816,7 @@ export default function App() {
           tab,
           !!updateInfo,
           settings.advancedSequenceLayout,
+          settings.showStopwatchOnMainWindow,
         );
         const { width, height } = await getClampedPanelSize(
           preferredSize,
@@ -782,6 +934,7 @@ export default function App() {
     dropdownOverflowBottom,
     settingsLoaded,
     settings.advancedSequenceLayout,
+    settings.showStopwatchOnMainWindow,
   ]);
 
   useEffect(() => {
@@ -965,6 +1118,22 @@ export default function App() {
     setStopKey((k) => k + 1);
   }
 
+  const sessionElapsedMs =
+    status.running && status.sessionStartedAtMs
+      ? Math.max(0, clockNowMs - status.sessionStartedAtMs)
+      : 0;
+  const stopwatchElapsedMs =
+    stopwatch.elapsedMs +
+    (stopwatch.running && stopwatch.startedAtMs
+      ? Math.max(0, clockNowMs - stopwatch.startedAtMs)
+      : 0);
+  const lastSessionDurationMs =
+    !status.running && status.lastSessionDurationMs > 0
+      ? status.lastSessionDurationMs
+      : settings.lastSessionDurationMs;
+  const showTimerWidget =
+    settings.showStopwatchOnMainWindow && tab !== "settings";
+
   return (
     <div className="app-root" data-tab={tab}>
       <TitleBar
@@ -992,6 +1161,20 @@ export default function App() {
         />
       )}
       <main className="panel-area">
+        {showTimerWidget && (
+          <TimerWidget
+            settings={settings}
+            update={updateSettings}
+            running={status.running}
+            paused={status.paused}
+            sessionElapsedMs={sessionElapsedMs}
+            lastSessionDurationMs={lastSessionDurationMs}
+            stopwatchElapsedMs={stopwatchElapsedMs}
+            stopwatchRunning={stopwatch.running}
+            onStopwatchToggle={handleStopwatchToggle}
+            onStopwatchReset={handleStopwatchReset}
+          />
+        )}
         {tab === "simple" && (
           <SimplePanel settings={settings} update={updateSettings} />
         )}

--- a/src/components/TimerWidget.css
+++ b/src/components/TimerWidget.css
@@ -1,0 +1,223 @@
+.timer-widget {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.25fr) minmax(0, 1.35fr);
+  gap: 0.625rem;
+  width: 100%;
+  flex: 0 0 auto;
+  margin-bottom: 0.75rem;
+}
+
+.timer-card {
+  min-width: 0;
+  min-height: 4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.125rem;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  box-shadow: var(--container-shadow);
+  overflow: hidden;
+}
+
+.timer-card[data-active="true"] {
+  border-color: var(--accent-green-ring);
+  box-shadow:
+    var(--container-shadow),
+    inset 0 0 0 1px var(--accent-green-soft);
+}
+
+.timer-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.timer-label {
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: var(--font-weight-md);
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.timer-value {
+  color: var(--text-primary);
+  font-size: 1.25rem;
+  font-weight: var(--font-weight-hv);
+  letter-spacing: -0.04em;
+  line-height: 1.05;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.timer-card[data-active="true"] .timer-value {
+  color: var(--accent-green-strong);
+  text-shadow:
+    0 0 10px var(--accent-green-glow-1),
+    0 0 18px var(--accent-green-glow-2);
+}
+
+.timer-subvalue {
+  color: var(--text-dim);
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-md);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.timer-card[data-active="true"] .timer-subvalue {
+  color: var(--text-muted);
+}
+
+.timer-status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--text-dim);
+  opacity: 0.55;
+  flex: 0 0 auto;
+}
+
+.timer-card[data-active="true"] .timer-status-dot {
+  background: var(--accent-green-strong);
+  opacity: 1;
+  box-shadow: 0 0 0 0.25rem var(--accent-green-soft);
+}
+
+.timer-actions,
+.timer-countdown-controls,
+.timer-seg-group {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.timer-actions {
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.timer-btn,
+.timer-pill-toggle,
+.timer-seg-btn {
+  font-family: var(--font-family-base);
+  font-weight: var(--font-weight-md);
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.timer-btn {
+  min-height: 1.5rem;
+  padding: 0.1875rem 0.5rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+}
+
+.timer-btn:hover:not(:disabled),
+.timer-pill-toggle:hover:not(:disabled),
+.timer-seg-btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+  border-color: var(--border-focus);
+  color: var(--text-primary);
+}
+
+.timer-btn:disabled,
+.timer-pill-toggle:disabled,
+.timer-seg-btn:disabled,
+.timer-countdown-input:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.timer-btn-primary {
+  color: var(--accent-green-strong);
+}
+
+.timer-btn-primary:hover:not(:disabled) {
+  background: var(--accent-green-soft);
+  border-color: var(--accent-green);
+}
+
+.timer-pill-toggle {
+  min-height: 1.375rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+}
+
+.timer-pill-toggle.active {
+  color: var(--accent-green-strong);
+  border-color: var(--accent-green-ring);
+  background: var(--accent-green-soft);
+}
+
+.timer-countdown-controls {
+  gap: 0.375rem;
+}
+
+.timer-countdown-input {
+  width: 3.5rem;
+  min-width: 0;
+  height: 1.5rem;
+  padding: 0 0.375rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-family: var(--font-family-base);
+  font-size: 0.8125rem;
+  font-weight: var(--font-weight-md);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.timer-countdown-input::-webkit-inner-spin-button,
+.timer-countdown-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.timer-countdown-input:focus {
+  border-color: var(--accent-green-ring);
+}
+
+.timer-countdown-input:disabled {
+  color: var(--text-dim);
+}
+
+.timer-seg-group {
+  flex-shrink: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-elevated);
+}
+
+.timer-seg-btn {
+  min-width: 1.375rem;
+  height: 1.375rem;
+  padding: 0 0.25rem;
+  border: none;
+  border-radius: 0;
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+}
+
+.timer-seg-btn.active {
+  background: var(--bg-input);
+  color: var(--text-primary);
+}

--- a/src/components/TimerWidget.tsx
+++ b/src/components/TimerWidget.tsx
@@ -1,0 +1,172 @@
+import type { ChangeEvent } from "react";
+import type { Settings, TimeLimitUnit } from "../store";
+import { formatTimerDuration, timeLimitDurationMs } from "../timerUtils";
+import "./TimerWidget.css";
+
+interface TimerWidgetProps {
+  settings: Settings;
+  update: (patch: Partial<Settings>) => void;
+  running: boolean;
+  paused: boolean;
+  sessionElapsedMs: number;
+  lastSessionDurationMs: number;
+  stopwatchElapsedMs: number;
+  stopwatchRunning: boolean;
+  onStopwatchToggle: () => void;
+  onStopwatchReset: () => void;
+}
+
+function normalizePositiveNumber(raw: string) {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return 1;
+  }
+
+  return Math.max(1, Math.floor(parsed));
+}
+
+function TimerValue({ value }: { value: number }) {
+  return <span className="timer-value">{formatTimerDuration(value)}</span>;
+}
+
+function TimerWidget({
+  settings,
+  update,
+  running,
+  paused,
+  sessionElapsedMs,
+  lastSessionDurationMs,
+  stopwatchElapsedMs,
+  stopwatchRunning,
+  onStopwatchToggle,
+  onStopwatchReset,
+}: TimerWidgetProps) {
+  const countdownMs = timeLimitDurationMs(settings);
+  const countdownRemainingMs = Math.max(0, countdownMs - sessionElapsedMs);
+  const stopwatchButtonLabel = stopwatchRunning
+    ? "Pause"
+    : stopwatchElapsedMs > 0
+      ? "Resume"
+      : "Start";
+
+  const handleCountdownToggle = () => {
+    const nextEnabled = !settings.timeLimitEnabled;
+    update({
+      timeLimitEnabled: nextEnabled,
+      clickLimitEnabled: nextEnabled ? false : settings.clickLimitEnabled,
+    });
+  };
+
+  const handleCountdownValueChange = (event: ChangeEvent<HTMLInputElement>) => {
+    update({ timeLimit: normalizePositiveNumber(event.target.value) });
+  };
+
+  const handleCountdownUnitChange = (timeLimitUnit: TimeLimitUnit) => {
+    update({ timeLimitUnit });
+  };
+
+  return (
+    <section className="timer-widget" aria-label="Timers">
+      <div className="timer-card timer-card--session" data-active={running}>
+        <div className="timer-card-head">
+          <span className="timer-label">Session</span>
+          <span className="timer-status-dot" aria-hidden="true" />
+        </div>
+        <TimerValue value={sessionElapsedMs} />
+        <span className="timer-subvalue">
+          {running
+            ? paused
+              ? "Paused"
+              : "Running"
+            : lastSessionDurationMs > 0
+              ? `Last ${formatTimerDuration(lastSessionDurationMs)}`
+              : "Ready"}
+        </span>
+      </div>
+
+      <div
+        className="timer-card timer-card--stopwatch"
+        data-active={stopwatchRunning}
+      >
+        <div className="timer-card-head">
+          <span className="timer-label">Stopwatch</span>
+          <div className="timer-actions">
+            <button
+              type="button"
+              className="timer-btn timer-btn-primary"
+              onClick={onStopwatchToggle}
+            >
+              {stopwatchButtonLabel}
+            </button>
+            <button
+              type="button"
+              className="timer-btn"
+              onClick={onStopwatchReset}
+              disabled={!stopwatchRunning && stopwatchElapsedMs === 0}
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+        <TimerValue value={stopwatchElapsedMs} />
+        <span className="timer-subvalue">
+          {stopwatchRunning ? "Counting" : "Independent timer"}
+        </span>
+      </div>
+
+      <div
+        className="timer-card timer-card--countdown"
+        data-active={settings.timeLimitEnabled}
+      >
+        <div className="timer-card-head">
+          <span className="timer-label">Auto-stop</span>
+          <button
+            type="button"
+            className={`timer-pill-toggle ${settings.timeLimitEnabled ? "active" : ""}`}
+            onClick={handleCountdownToggle}
+            aria-pressed={settings.timeLimitEnabled}
+            disabled={running}
+            title={
+              running ? "Countdown changes apply before starting" : undefined
+            }
+          >
+            {settings.timeLimitEnabled ? "On" : "Off"}
+          </button>
+        </div>
+        <div className="timer-countdown-controls">
+          <input
+            className="timer-countdown-input"
+            type="number"
+            min={1}
+            value={settings.timeLimit}
+            onChange={handleCountdownValueChange}
+            aria-label="Countdown duration"
+            disabled={running}
+          />
+          <div className="timer-seg-group" aria-label="Countdown unit">
+            {(["s", "m", "h"] as const).map((unit) => (
+              <button
+                type="button"
+                key={unit}
+                className={`timer-seg-btn ${settings.timeLimitUnit === unit ? "active" : ""}`}
+                onClick={() => handleCountdownUnitChange(unit)}
+                disabled={running}
+              >
+                {unit}
+              </button>
+            ))}
+          </div>
+        </div>
+        <span className="timer-subvalue">
+          {settings.timeLimitEnabled
+            ? running
+              ? `${formatTimerDuration(countdownRemainingMs)} left`
+              : `Stops after ${formatTimerDuration(countdownMs)}`
+            : "Optional countdown"}
+        </span>
+      </div>
+    </section>
+  );
+}
+
+export default TimerWidget;

--- a/src/components/panels/SettingsPanel.tsx
+++ b/src/components/panels/SettingsPanel.tsx
@@ -410,6 +410,7 @@ export default function SettingsPanel({
   };
 
   const hasStats = stats !== null && stats.totalSessions > 0;
+  const hasLastSession = settings.lastSessionDurationMs > 0;
   const presetLimitReached = settings.presets.length >= MAX_PRESETS;
   const activeEditingPresetId = running ? null : editingPresetId;
   const activeConfirmingDeleteId = running ? null : confirmingDeleteId;
@@ -438,6 +439,7 @@ export default function SettingsPanel({
     try {
       const next = await invoke<CumulativeStats>("reset_stats");
       setStats(next);
+      update({ lastSessionDurationMs: 0 });
     } catch {
       // swallow ? failure leaves stats unchanged
     } finally {
@@ -611,37 +613,49 @@ export default function SettingsPanel({
               </span>
             </div>
           </div>
-          {hasStats ? (
+          {hasStats || hasLastSession ? (
             <div className="stats-grid">
-              <div className="stats-cell">
-                <span className="stats-cell-label">Total Clicks</span>
-                <span className="stats-cell-value">
-                  {formatNumber(stats.totalClicks, language)}
-                </span>
-              </div>
-              <div className="stats-cell">
-                <span className="stats-cell-label">Total Time Clicking</span>
-                <span className="stats-cell-value">
-                  {formatTime(stats.totalTimeSecs, language)}
-                </span>
-              </div>
-              <div className="stats-cell">
-                <span className="stats-cell-label">Average CPU</span>
-                <span className="stats-cell-value">
-                  {formatCpu(stats.avgCpu, language, "N/A")}
-                </span>
-              </div>
-              <div className="stats-cell">
-                <span className="stats-cell-label">Sessions</span>
-                <span className="stats-cell-value">
-                  {formatNumber(stats.totalSessions, language)}
-                </span>
-              </div>
+              {hasLastSession && (
+                <div className="stats-cell">
+                  <span className="stats-cell-label">Last Session</span>
+                  <span className="stats-cell-value">
+                    {formatTime(settings.lastSessionDurationMs / 1000, language)}
+                  </span>
+                </div>
+              )}
+              {hasStats && (
+                <>
+                  <div className="stats-cell">
+                    <span className="stats-cell-label">Total Clicks</span>
+                    <span className="stats-cell-value">
+                      {formatNumber(stats.totalClicks, language)}
+                    </span>
+                  </div>
+                  <div className="stats-cell">
+                    <span className="stats-cell-label">Total Time Clicking</span>
+                    <span className="stats-cell-value">
+                      {formatTime(stats.totalTimeSecs, language)}
+                    </span>
+                  </div>
+                  <div className="stats-cell">
+                    <span className="stats-cell-label">Average CPU</span>
+                    <span className="stats-cell-value">
+                      {formatCpu(stats.avgCpu, language, "N/A")}
+                    </span>
+                  </div>
+                  <div className="stats-cell">
+                    <span className="stats-cell-label">Sessions</span>
+                    <span className="stats-cell-value">
+                      {formatNumber(stats.totalSessions, language)}
+                    </span>
+                  </div>
+                </>
+              )}
             </div>
           ) : (
             <div className="stats-empty">No session data yet.</div>
           )}
-          {hasStats && (
+          {(hasStats || hasLastSession) && (
             <div className="settings-row">
               <div className="settings-label-group">
                 <span className="settings-label">Clear Stats</span>
@@ -816,6 +830,28 @@ export default function SettingsPanel({
                   key={String(option.value)}
                   className={`settings-seg-btn ${settings.showStopReason === option.value ? "active" : ""}`}
                   onClick={() => update({ showStopReason: option.value })}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="settings-row">
+            <div className="settings-label-group">
+              <span className="settings-label">Main Window Timers</span>
+              <span className="settings-sublabel">
+                Keep the session timer and stopwatch visible while using the app.
+              </span>
+            </div>
+            <div className="settings-seg-group">
+              {onOffOptions.map((option) => (
+                <button
+                  key={String(option.value)}
+                  className={`settings-seg-btn ${settings.showStopwatchOnMainWindow === option.value ? "active" : ""}`}
+                  onClick={() =>
+                    update({ showStopwatchOnMainWindow: option.value })
+                  }
                 >
                   {option.label}
                 </button>

--- a/src/settingsSchema.ts
+++ b/src/settingsSchema.ts
@@ -300,6 +300,14 @@ const SETTINGS_ONLY_FIELDS = {
     default: true,
     ui: { section: "behavior", control: "toggle" },
   },
+  showStopwatchOnMainWindow: {
+    default: true,
+    ui: { section: "behavior", control: "toggle" },
+  },
+  lastSessionDurationMs: {
+    default: 0,
+    limit: { min: 0 },
+  },
   strictHotkeyModifiers: {
     default: false,
     ui: { section: "behavior", control: "toggle" },
@@ -444,6 +452,7 @@ export const SETTINGS_UI_SCHEMA = [
       "alwaysOnTop",
       "showStopOverlay",
       "showStopReason",
+      "showStopwatchOnMainWindow",
       "strictHotkeyModifiers",
       "taskSwitcherStopEnabled",
       "extendedClickSpeedLimit",

--- a/src/store.ts
+++ b/src/store.ts
@@ -37,6 +37,8 @@ export interface ClickerStatus {
   warning: string | null;
   activeSequenceIndex: number | null;
   activeSequenceTick: number;
+  sessionStartedAtMs: number | null;
+  lastSessionDurationMs: number;
 }
 
 export interface AppInfo {

--- a/src/timerUtils.ts
+++ b/src/timerUtils.ts
@@ -1,0 +1,29 @@
+import type { Settings } from "./store";
+
+export function formatTimerDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(
+    2,
+    "0",
+  )}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function timeLimitDurationMs(settings: Pick<Settings, "timeLimit" | "timeLimitUnit">): number {
+  const value = Math.max(0, Number(settings.timeLimit) || 0);
+  const seconds =
+    settings.timeLimitUnit === "h"
+      ? value * 3600
+      : settings.timeLimitUnit === "m"
+        ? value * 60
+        : value;
+
+  return Math.max(0, Math.round(seconds * 1000));
+}
+
+export function timeLimitStopReason(durationMs: number): string {
+  return `Time limit reached (${(durationMs / 1000).toFixed(1)}s)`;
+}


### PR DESCRIPTION
Closes https://github.com/Blur009/Blur-AutoClicker/issues/238

## Summary
- Add a main-window timer widget with live session elapsed time, last session duration, and independent stopwatch controls.
- Add optional auto-stop countdown controls backed by the existing time limit behavior.
- Persist the last session duration and show it in usage statistics.

## Testing
- npm run frontend:build
- npm run lint
- cargo test --manifest-path src-tauri/Cargo.toml