### PR TITLE
feat: Add keyboard sequence actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Most auto clickers aren't accurate at high speeds. Set it to 50 CPS and you migh
 - Corner and edge stopping (auto-off near screen edges)
 - Click and time limits
 - Double clicks
-- Position clicking (pick a spot, mouse moves and clicks there)
+- Sequence Actions for round-robin mouse clicks and keyboard presses
 - Per second, minute, hour, or day
 
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -34,10 +34,60 @@ pub struct ProcessListEntry {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SequenceTargetKind {
+    Mouse {
+        x: i32,
+        y: i32,
+    },
+    Key {
+        key_code: u16,
+        keyboard_uppercase: bool,
+        hold_ms: u32,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SequenceTarget {
-    pub x: i32,
-    pub y: i32,
+    pub kind: SequenceTargetKind,
     pub clicks: usize,
+}
+
+impl SequenceTarget {
+    pub fn mouse(x: i32, y: i32, clicks: usize) -> Self {
+        Self {
+            kind: SequenceTargetKind::Mouse { x, y },
+            clicks,
+        }
+    }
+
+    pub fn key(key_code: u16, keyboard_uppercase: bool, hold_ms: u32, clicks: usize) -> Self {
+        Self {
+            kind: SequenceTargetKind::Key {
+                key_code,
+                keyboard_uppercase,
+                hold_ms,
+            },
+            clicks,
+        }
+    }
+
+    pub fn mouse_position(self) -> Option<(i32, i32)> {
+        match self.kind {
+            SequenceTargetKind::Mouse { x, y } => Some((x, y)),
+            SequenceTargetKind::Key { .. } => None,
+        }
+    }
+
+    pub fn key_press(self) -> Option<(u16, bool, u32)> {
+        match self.kind {
+            SequenceTargetKind::Key {
+                key_code,
+                keyboard_uppercase,
+                hold_ms,
+            } => Some((key_code, keyboard_uppercase, hold_ms)),
+            SequenceTargetKind::Mouse { .. } => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src-tauri/src/engine/worker.rs
+++ b/src-tauri/src/engine/worker.rs
@@ -9,6 +9,7 @@ use crate::engine::stats::{print_run_stats, record_run};
 use crate::error::poisoned_inner;
 use crate::error::AppError;
 use crate::error::AppResult;
+use crate::settings::SequencePointAction;
 use crate::ClickerSettings;
 use crate::ClickerState;
 use crate::ClickerStatusPayload;
@@ -53,6 +54,23 @@ impl ClickerConfig {
     pub fn use_sequence(&self) -> bool {
         self.sequence_enabled && !self.sequence_points.is_empty()
     }
+}
+
+fn auto_key_conflicts_with_hotkey(
+    binding: &crate::hotkeys::HotkeyBinding,
+    key_code: u16,
+    keyboard_uppercase: bool,
+) -> bool {
+    if binding.main_vk != key_code as i32 {
+        return false;
+    }
+
+    let conflicts_with_plain_key =
+        !binding.ctrl && !binding.alt && !binding.shift && !binding.super_key;
+    let conflicts_with_uppercase_key =
+        keyboard_uppercase && binding.shift && !binding.ctrl && !binding.alt && !binding.super_key;
+
+    conflicts_with_plain_key || conflicts_with_uppercase_key
 }
 
 fn calibrate_cycle_freq() -> f64 {
@@ -137,29 +155,29 @@ pub fn start_clicker_inner(app: &AppHandle) -> AppResult<ClickerStatusPayload> {
     let settings = state.settings.lock().unwrap_or_else(poisoned_inner).clone();
     let config = build_config(&settings)?;
 
-    // Prevent feedback loop: keyboard key must not match a modifier-free hotkey
-    if config.input_type == 1 && config.key_code > 0 {
-        let hotkey_binding = state
-            .registered_hotkey
-            .lock()
-            .unwrap_or_else(poisoned_inner)
-            .clone();
-        if let Some(binding) = hotkey_binding {
-            if binding.main_vk == config.key_code as i32 {
-                let conflicts_with_plain_key =
-                    !binding.ctrl && !binding.alt && !binding.shift && !binding.super_key;
-                let conflicts_with_uppercase_key = config.keyboard_uppercase
-                    && binding.shift
-                    && !binding.ctrl
-                    && !binding.alt
-                    && !binding.super_key;
+    // Prevent feedback loop: auto-press keys must not match modifier-free hotkeys.
+    let hotkey_binding = state
+        .registered_hotkey
+        .lock()
+        .unwrap_or_else(poisoned_inner)
+        .clone();
+    if let Some(binding) = hotkey_binding {
+        let global_key_conflicts = config.input_type == 1
+            && config.key_code > 0
+            && auto_key_conflicts_with_hotkey(&binding, config.key_code, config.keyboard_uppercase);
+        let sequence_key_conflicts = config.sequence_points.iter().any(|target| {
+            target
+                .key_press()
+                .map(|(key_code, keyboard_uppercase, _hold_ms)| {
+                    auto_key_conflicts_with_hotkey(&binding, key_code, keyboard_uppercase)
+                })
+                .unwrap_or(false)
+        });
 
-                if conflicts_with_plain_key || conflicts_with_uppercase_key {
-                    return Err(AppError::HotkeyConflict(String::from(
-                        "The auto-press key conflicts with your hotkey. Use a modifier on the hotkey (e.g. Ctrl+key) or pick a different key.",
-                    )));
-                }
-            }
+        if global_key_conflicts || sequence_key_conflicts {
+            return Err(AppError::HotkeyConflict(String::from(
+                "An auto-press key conflicts with your hotkey. Use a modifier on the hotkey (e.g. Ctrl+key) or pick a different key.",
+            )));
         }
     }
 
@@ -277,7 +295,7 @@ fn current_cycle_target(config: &ClickerConfig, sequence_index: usize) -> Sequen
         config.sequence_points[safe_index]
     } else {
         let (x, y) = get_cursor_pos();
-        SequenceTarget { x, y, clicks: 1 }
+        SequenceTarget::mouse(x, y, 1)
     }
 }
 
@@ -301,11 +319,43 @@ pub fn build_config(settings: &ClickerSettings) -> AppResult<ClickerConfig> {
         0u16
     };
 
-    if is_keyboard && key_code == 0 {
+    let sequence_mode_requested = settings.sequence_enabled && !settings.sequence_points.is_empty();
+
+    if is_keyboard && key_code == 0 && !sequence_mode_requested {
         return Err(AppError::NoKeySelected);
     }
     let keyboard_uppercase =
         is_keyboard && settings.keyboard_key_case == "upper" && is_alphabetic_vk(key_code);
+
+    let mut sequence_points = Vec::with_capacity(settings.sequence_points.len());
+    if settings.sequence_enabled {
+        for point in &settings.sequence_points {
+            let clicks = point.clicks.clamp(1, 100000) as usize;
+            match point.action {
+                SequencePointAction::Mouse => {
+                    sequence_points.push(SequenceTarget::mouse(point.x, point.y, clicks));
+                }
+                SequencePointAction::Key => {
+                    if point.key.trim().is_empty() {
+                        return Err(AppError::NoKeySelected);
+                    }
+                    let key_code =
+                        match crate::hotkeys::parse_hotkey_main_key(&point.key, &point.key) {
+                            Ok((vk, _)) => vk as u16,
+                            Err(_) => return Err(AppError::UnknownKey(point.key.clone())),
+                        };
+                    let keyboard_uppercase =
+                        point.key_case == "upper" && is_alphabetic_vk(key_code);
+                    sequence_points.push(SequenceTarget::key(
+                        key_code,
+                        keyboard_uppercase,
+                        point.hold_ms.clamp(1, 5000),
+                        clicks,
+                    ));
+                }
+            }
+        }
+    }
 
     let time_limit_secs = if settings.time_limit_enabled {
         Some(match settings.time_limit_unit.as_str() {
@@ -339,15 +389,7 @@ pub fn build_config(settings: &ClickerSettings) -> AppResult<ClickerConfig> {
         double_click_enabled: settings.double_click_enabled,
         double_click_gap_ms: system_double_click_gap_ms(),
         sequence_enabled: settings.sequence_enabled,
-        sequence_points: settings
-            .sequence_points
-            .iter()
-            .map(|point| SequenceTarget {
-                x: point.x,
-                y: point.y,
-                clicks: point.clicks.clamp(1, 100000) as usize,
-            })
-            .collect(),
+        sequence_points,
         offset: 2.0,
         offset_chance: 21.6,
         smoothing: 1,
@@ -484,7 +526,6 @@ struct ClickerContext {
     down_flag: u32,
     up_flag: u32,
     batch_size: usize,
-    has_position: bool,
     use_smoothing: bool,
     single_plan: ClickCyclePlan,
     double_plan: ClickCyclePlan,
@@ -493,10 +534,15 @@ struct ClickerContext {
 impl ClickerContext {
     fn new(config: &ClickerConfig) -> Self {
         let is_keyboard = config.input_type == 1 && config.key_code > 0;
-        let (down_flag, up_flag) = if is_keyboard {
-            (0, 0)
-        } else {
+        let sequence_has_mouse_target = config
+            .sequence_points
+            .iter()
+            .any(|target| target.mouse_position().is_some());
+        let needs_mouse_flags = !is_keyboard || sequence_has_mouse_target;
+        let (down_flag, up_flag) = if needs_mouse_flags {
             get_button_flags(config.button)
+        } else {
+            (0, 0)
         };
         let cps = if config.interval_secs > 0.0 {
             1.0 / config.interval_secs
@@ -530,7 +576,6 @@ impl ClickerContext {
             down_flag,
             up_flag,
             batch_size,
-            has_position: config.use_sequence(),
             use_smoothing: config.smoothing == 1 && cps < 50.0,
             single_plan: ClickCyclePlan::single(hold_ms),
             double_plan: ClickCyclePlan::double(hold_ms, cycle_ms, config.double_click_gap_ms),
@@ -552,11 +597,7 @@ struct LoopState {
 impl LoopState {
     fn new(config: &ClickerConfig) -> Self {
         let target = current_cycle_target(config, 0);
-        let (target_x, target_y) = if config.use_sequence() {
-            (target.x, target.y)
-        } else {
-            get_cursor_pos()
-        };
+        let (target_x, target_y) = target.mouse_position().unwrap_or_else(get_cursor_pos);
         Self {
             click_count: 0,
             stop_reason: String::from("Stopped"),
@@ -624,18 +665,21 @@ fn update_target(
     rng: &mut SmallRng,
     st: &mut LoopState,
 ) {
-    if !ctx.has_position {
+    if !config.use_sequence() {
         return;
     }
     let target = current_cycle_target(config, st.sequence_index);
+    let Some((target_x, target_y)) = target.mouse_position() else {
+        return;
+    };
     if config.offset_chance > 0.0 && rng.next_f64() * 100.0 <= config.offset_chance {
         let angle = rng.next_f64() * 2.0 * PI;
         let radius = rng.next_f64().sqrt() * config.offset;
-        st.target_x = (target.x as f64 + radius * angle.cos()) as i32;
-        st.target_y = (target.y as f64 + radius * angle.sin()) as i32;
+        st.target_x = (target_x as f64 + radius * angle.cos()) as i32;
+        st.target_y = (target_y as f64 + radius * angle.sin()) as i32;
     } else {
-        st.target_x = target.x;
-        st.target_y = target.y;
+        st.target_x = target_x;
+        st.target_y = target_y;
     }
     let should_move = st.moved_sequence_index != Some(st.sequence_index) || config.offset > 0.0;
     if !should_move {
@@ -679,7 +723,25 @@ fn run_batch(
     } else {
         usize::MAX
     };
-    let batch = plan_cycle_batch(requested, remaining, config.double_click_enabled);
+    let sequence_target = if config.use_sequence() {
+        Some(current_cycle_target(config, st.sequence_index))
+    } else {
+        None
+    };
+    let sequence_key_press = sequence_target.and_then(SequenceTarget::key_press);
+    let key_press = sequence_key_press
+        .map(|(key_code, keyboard_uppercase, hold_ms)| {
+            (key_code, keyboard_uppercase, Some(hold_ms))
+        })
+        .or_else(|| {
+            (!config.use_sequence() && ctx.is_keyboard).then_some((
+                config.key_code,
+                config.keyboard_uppercase,
+                None,
+            ))
+        });
+    let double_click_enabled = config.double_click_enabled && sequence_key_press.is_none();
+    let batch = plan_cycle_batch(requested, remaining, double_click_enabled);
     if batch.cycles == 0 {
         return false;
     }
@@ -692,12 +754,15 @@ fn run_batch(
     };
     st.next_batch_time += Duration::from_secs_f64(batch_dur.max(0.001));
 
-    if ctx.is_keyboard {
+    if let Some((key_code, keyboard_uppercase, hold_ms)) = key_press {
+        let single_plan = hold_ms
+            .map(ClickCyclePlan::single)
+            .unwrap_or(ctx.single_plan);
         if batch.double_cycles > 0 {
             send_key_presses(
-                config.key_code,
+                key_code,
                 batch.double_cycles,
-                config.keyboard_uppercase,
+                keyboard_uppercase,
                 ctx.double_plan,
                 control,
                 should_abort,
@@ -705,10 +770,10 @@ fn run_batch(
         }
         if batch.single_cycles > 0 {
             send_key_presses(
-                config.key_code,
+                key_code,
                 batch.single_cycles,
-                config.keyboard_uppercase,
-                ctx.single_plan,
+                keyboard_uppercase,
+                single_plan,
                 control,
                 should_abort,
             );
@@ -791,9 +856,11 @@ pub fn start_clicker(config: ClickerConfig, control: RunControl) -> RunOutcome {
     let ctx = ClickerContext::new(&config);
     let mut st = LoopState::new(&config);
 
-    if ctx.has_position {
-        move_mouse(st.target_x, st.target_y);
-        st.moved_sequence_index = Some(0);
+    if config.use_sequence() {
+        if let Some((target_x, target_y)) = current_cycle_target(&config, 0).mouse_position() {
+            move_mouse(target_x, target_y);
+            st.moved_sequence_index = Some(0);
+        }
     }
     if config.use_sequence() {
         let state = control.app.state::<ClickerState>();
@@ -957,42 +1024,78 @@ mod tests {
         let mut config = sample_config();
         config.sequence_enabled = true;
         config.sequence_points = vec![
-            SequenceTarget {
-                x: 10,
-                y: 10,
-                clicks: 1,
-            },
-            SequenceTarget {
-                x: 20,
-                y: 20,
-                clicks: 1,
-            },
+            SequenceTarget::mouse(10, 10, 1),
+            SequenceTarget::mouse(20, 20, 1),
         ];
 
         assert_eq!(
             current_cycle_target(&config, 0),
-            SequenceTarget {
-                x: 10,
-                y: 10,
-                clicks: 1
-            }
+            SequenceTarget::mouse(10, 10, 1)
         );
         assert_eq!(
             current_cycle_target(&config, 1),
-            SequenceTarget {
-                x: 20,
-                y: 20,
-                clicks: 1
-            }
+            SequenceTarget::mouse(20, 20, 1)
         );
         assert_eq!(
             current_cycle_target(&config, 2),
-            SequenceTarget {
-                x: 10,
-                y: 10,
-                clicks: 1
-            }
+            SequenceTarget::mouse(10, 10, 1)
         );
+    }
+
+    #[test]
+    fn build_config_maps_key_sequence_points_to_keyboard_targets() {
+        let mut settings = sample_settings();
+        settings.sequence_enabled = true;
+        settings.sequence_points = vec![
+            crate::settings::SequencePoint {
+                id: "mouse-1".to_string(),
+                action: SequencePointAction::Mouse,
+                x: 10,
+                y: 20,
+                key: String::new(),
+                key_case: "lower".to_string(),
+                hold_ms: 30,
+                clicks: 2,
+            },
+            crate::settings::SequencePoint {
+                id: "key-1".to_string(),
+                action: SequencePointAction::Key,
+                x: 0,
+                y: 0,
+                key: "w".to_string(),
+                key_case: "upper".to_string(),
+                hold_ms: 35,
+                clicks: 1,
+            },
+        ];
+
+        let config = build_config(&settings).expect("mixed sequence should parse");
+
+        assert_eq!(
+            config.sequence_points,
+            vec![
+                SequenceTarget::mouse(10, 20, 2),
+                SequenceTarget::key(b'W' as u16, true, 35, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn keyboard_mode_mixed_sequence_keeps_mouse_flags_available() {
+        let mut config = sample_config();
+        config.input_type = 1;
+        config.key_code = b'W' as u16;
+        config.sequence_enabled = true;
+        config.sequence_points = vec![
+            SequenceTarget::key(b'W' as u16, false, 30, 1),
+            SequenceTarget::mouse(10, 20, 1),
+        ];
+
+        let ctx = ClickerContext::new(&config);
+        let (expected_down_flag, expected_up_flag) = get_button_flags(config.button);
+
+        assert_eq!(ctx.down_flag, expected_down_flag);
+        assert_eq!(ctx.up_flag, expected_up_flag);
     }
 
     #[test]

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -5,6 +5,7 @@ use crate::engine::mouse::{
 use crate::error::poisoned_inner;
 use crate::error::AppError;
 use crate::error::AppResult;
+use crate::settings::SequencePointAction;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -144,13 +145,20 @@ pub fn show_sequence_points_overlay(app: &AppHandle) -> AppResult<()> {
     #[cfg(target_os = "windows")]
     {
         sync_overlay_bounds(&window)?;
-        if !points.is_empty() {
+        if points
+            .iter()
+            .any(|point| point.action == SequencePointAction::Mouse)
+        {
             show_overlay_window(&window)?;
         }
     }
 
     emit_sequence_points(&window, bounds, &points, false);
-    if points.is_empty() && !SEQUENCE_PICK_OVERLAY_ACTIVE.load(Ordering::SeqCst) {
+    if !points
+        .iter()
+        .any(|point| point.action == SequencePointAction::Mouse)
+        && !SEQUENCE_PICK_OVERLAY_ACTIVE.load(Ordering::SeqCst)
+    {
         *LAST_ZONE_SHOW.lock().unwrap_or_else(poisoned_inner) = None;
         hide_overlay_window(&window);
     } else {
@@ -275,6 +283,7 @@ fn emit_sequence_points(
 ) {
     let points_payload: Vec<_> = points
         .iter()
+        .filter(|point| point.action == SequencePointAction::Mouse)
         .map(|point| {
             let offset = VirtualScreenRect::new(point.x, point.y, 1, 1).offset_from(bounds);
             serde_json::json!({

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -2,19 +2,41 @@
 // When adding or changing a backend-facing setting, keep the section and
 // default in sync with the TypeScript field definitions.
 
+#[derive(Clone, Copy, serde::Deserialize, serde::Serialize, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SequencePointAction {
+    #[default]
+    Mouse,
+    Key,
+}
+
 #[derive(Clone, serde::Deserialize, serde::Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SequencePoint {
     #[serde(default)]
     pub id: String,
+    #[serde(default)]
+    pub action: SequencePointAction,
+    #[serde(default)]
     pub x: i32,
+    #[serde(default)]
     pub y: i32,
+    #[serde(default)]
+    pub key: String,
+    #[serde(default = "default_keyboard_key_case")]
+    pub key_case: String,
+    #[serde(default = "default_sequence_key_hold_ms")]
+    pub hold_ms: u32,
     #[serde(default = "default_sequence_point_clicks")]
     pub clicks: u32,
 }
 
 fn default_sequence_point_clicks() -> u32 {
     1
+}
+
+fn default_sequence_key_hold_ms() -> u32 {
+    30
 }
 
 fn default_keyboard_key_case() -> String {

--- a/src/__tests__/DutyCycleSection.test.tsx
+++ b/src/__tests__/DutyCycleSection.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { createDefaultSettings } from "../settingsSchema";
+import DutyCycleSection from "../components/panels/advanced/DutyCycleSection";
+
+describe("DutyCycleSection", () => {
+  it("disables Click Duration for enabled key-only sequences", () => {
+    const settings = {
+      ...createDefaultSettings("test"),
+      sequenceEnabled: true,
+      sequencePoints: [
+        {
+          id: "key",
+          action: "key" as const,
+          key: "w",
+          keyCase: "lower" as const,
+          holdMs: 30,
+          clicks: 1,
+        },
+      ],
+    };
+
+    render(
+      <DutyCycleSection
+        settings={settings}
+        update={vi.fn()}
+        showInfo={false}
+      />,
+    );
+
+    expect(screen.getByRole("spinbutton")).toBeDisabled();
+  });
+
+  it("keeps Click Duration editable when a sequence includes mouse actions", () => {
+    const settings = {
+      ...createDefaultSettings("test"),
+      sequenceEnabled: true,
+      sequencePoints: [
+        {
+          id: "mouse",
+          action: "mouse" as const,
+          x: 10,
+          y: 20,
+          clicks: 1,
+        },
+      ],
+    };
+
+    render(
+      <DutyCycleSection
+        settings={settings}
+        update={vi.fn()}
+        showInfo={false}
+      />,
+    );
+
+    expect(screen.getByRole("spinbutton")).not.toBeDisabled();
+  });
+});

--- a/src/__tests__/settingsSchema.test.ts
+++ b/src/__tests__/settingsSchema.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SEQUENCE_KEY_HOLD_MS,
+  SETTINGS_LIMITS,
+  hasKeyOnlySequenceActions,
+  sanitizeSettings,
+  type SequencePoint,
+  type Settings,
+} from "../settingsSchema";
+
+describe("settings schema sequence actions", () => {
+  it("keeps legacy mouse sequence points compatible", () => {
+    const settings = sanitizeSettings(
+      {
+        sequencePoints: [
+          { id: "legacy-mouse", x: 12.8, y: 34.2, clicks: 2.9 },
+          { id: "invalid-mouse", action: "mouse", x: "bad", y: 20 },
+        ],
+      } as unknown as Partial<Settings>,
+      "test",
+    );
+
+    expect(settings.sequencePoints).toEqual([
+      {
+        id: "legacy-mouse",
+        action: "mouse",
+        x: 12,
+        y: 34,
+        clicks: 2,
+      },
+    ]);
+  });
+
+  it("sanitizes key sequence points with safe defaults and limits", () => {
+    const settings = sanitizeSettings(
+      {
+        sequencePoints: [
+          {
+            id: "key-with-default-hold",
+            action: "key",
+            key: " W ",
+            keyCase: "upper",
+            clicks: 2.9,
+          },
+          {
+            id: "key-with-limited-hold",
+            action: "key",
+            key: 42,
+            keyCase: "invalid",
+            holdMs: 999999,
+            clicks: -5,
+          },
+        ],
+      } as unknown as Partial<Settings>,
+      "test",
+    );
+
+    expect(settings.sequencePoints).toEqual([
+      {
+        id: "key-with-default-hold",
+        action: "key",
+        key: "W",
+        keyCase: "upper",
+        holdMs: DEFAULT_SEQUENCE_KEY_HOLD_MS,
+        clicks: 2,
+      },
+      {
+        id: "key-with-limited-hold",
+        action: "key",
+        key: "",
+        keyCase: "lower",
+        holdMs: SETTINGS_LIMITS.sequenceKeyHoldMs.max,
+        clicks: 1,
+      },
+    ]);
+  });
+
+  it("only marks click duration unavailable for enabled key-only sequences", () => {
+    const keyPoint: SequencePoint = {
+      id: "key",
+      action: "key",
+      key: "w",
+      keyCase: "lower",
+      holdMs: DEFAULT_SEQUENCE_KEY_HOLD_MS,
+      clicks: 1,
+    };
+    const mousePoint: SequencePoint = {
+      id: "mouse",
+      action: "mouse",
+      x: 10,
+      y: 20,
+      clicks: 1,
+    };
+
+    expect(
+      hasKeyOnlySequenceActions({
+        sequenceEnabled: false,
+        sequencePoints: [keyPoint],
+      }),
+    ).toBe(false);
+    expect(
+      hasKeyOnlySequenceActions({
+        sequenceEnabled: true,
+        sequencePoints: [],
+      }),
+    ).toBe(false);
+    expect(
+      hasKeyOnlySequenceActions({
+        sequenceEnabled: true,
+        sequencePoints: [keyPoint],
+      }),
+    ).toBe(true);
+    expect(
+      hasKeyOnlySequenceActions({
+        sequenceEnabled: true,
+        sequencePoints: [keyPoint, mousePoint],
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/components/panels/SimplePanel.css
+++ b/src/components/panels/SimplePanel.css
@@ -55,6 +55,10 @@
   max-width: 100%;
 }
 
+.simple-control-disabled {
+  opacity: 0.45;
+}
+
 .simple-control-label {
   color: color-mix(in srgb, var(--text-primary) 82%, var(--text-muted));
   font-size: 0.875rem;
@@ -123,6 +127,10 @@
   padding: 0;
   margin: 0;
   text-align: right;
+}
+
+.simple-inline-input:disabled {
+  cursor: not-allowed;
 }
 
 .simple-number-input {

--- a/src/components/panels/SimplePanel.tsx
+++ b/src/components/panels/SimplePanel.tsx
@@ -9,6 +9,7 @@ import type { MouseButton, Settings } from "../../store";
 import CadenceInput from "../CadenceInput";
 import HotkeyCaptureInput from "../HotkeyCaptureInput";
 import {
+  hasKeyOnlySequenceActions,
   MODE_OPTIONS,
   MOUSE_BUTTON_OPTIONS,
   SETTINGS_LIMITS,
@@ -16,6 +17,7 @@ import {
 import { isAlphabeticKeyboardKey } from "../../keyboardKeyCase";
 import { conflictsWithAutoPressKey } from "../../hotkeys";
 import KeyCaptureInput from "../KeyCaptureInput";
+import UnavailableReason from "../UnavailableReason";
 import { AdvDropdown } from "./advanced/shared";
 import "./SimplePanel.css";
 
@@ -84,6 +86,7 @@ function NumberField({
   max,
   onChange,
   width,
+  disabled = false,
 }: {
   label: string;
   value: number;
@@ -91,6 +94,7 @@ function NumberField({
   max: number;
   onChange: (next: number) => void;
   width: string;
+  disabled?: boolean;
 }) {
   return (
     <>
@@ -108,7 +112,9 @@ function NumberField({
         value={value}
         min={min}
         max={max}
+        disabled={disabled}
         onChange={(event: ChangeEvent<HTMLInputElement>) => {
+          if (disabled) return;
           const normalized = normalizeRaw(event.target.value);
           if (normalized !== event.target.value) {
             event.target.value = normalized;
@@ -116,6 +122,7 @@ function NumberField({
           onChange(parseRawNumber(normalized));
         }}
         onBlur={(event) => {
+          if (disabled) return;
           const normalized = normalizeRaw(event.target.value);
           if (normalized !== event.target.value) {
             event.target.value = normalized;
@@ -123,6 +130,7 @@ function NumberField({
           onChange(clamp(parseRawNumber(normalized), min, max));
         }}
         onWheel={(event) =>
+          !disabled &&
           handleWheelStep(event, value, min, max, (next) => onChange(next))
         }
       />
@@ -167,6 +175,9 @@ function SimplePanel({ settings, update }: SimplePanelProps) {
     );
   const hotkeyConflicts = hasConflict ? ["Auto-press key"] : [];
   const autoPressKeyConflicts = hasConflict ? ["Hotkey"] : [];
+  const clickDurationDisabled = hasKeyOnlySequenceActions(settings);
+  const clickDurationDisabledReason =
+    "Key sequence actions use each row's hold ms value instead of Click Duration.";
 
   return (
     <div className="vcontainer simple-panel">
@@ -272,16 +283,27 @@ function SimplePanel({ settings, update }: SimplePanelProps) {
           )}
         </ControlBox>
 
-        <ControlBox className="simple-row-item">
-          <NumberField
-            label="Click Duration"
-            value={settings.dutyCycle}
-            min={SETTINGS_LIMITS.dutyCycle.min!}
-            max={SETTINGS_LIMITS.dutyCycle.max!}
-            onChange={(next) => update({ dutyCycle: next })}
-            width={dynamicChWidth(settings.dutyCycle)}
-          />
-        </ControlBox>
+        <UnavailableReason
+          reason={
+            clickDurationDisabled ? clickDurationDisabledReason : undefined
+          }
+        >
+          <ControlBox
+            className={`simple-row-item ${
+              clickDurationDisabled ? "simple-control-disabled" : ""
+            }`}
+          >
+            <NumberField
+              label="Click Duration"
+              value={settings.dutyCycle}
+              min={SETTINGS_LIMITS.dutyCycle.min!}
+              max={SETTINGS_LIMITS.dutyCycle.max!}
+              onChange={(next) => update({ dutyCycle: next })}
+              width={dynamicChWidth(settings.dutyCycle)}
+              disabled={clickDurationDisabled}
+            />
+          </ControlBox>
+        </UnavailableReason>
 
         <ControlBox className="simple-row-item">
           <NumberField

--- a/src/components/panels/advanced/AdvancedPanel.css
+++ b/src/components/panels/advanced/AdvancedPanel.css
@@ -447,6 +447,14 @@ input[type="number"]::-webkit-outer-spin-button {
   flex-wrap: wrap;
 }
 
+.adv-control-disabled {
+  opacity: 0.45;
+}
+
+.adv-number-sm:disabled {
+  cursor: not-allowed;
+}
+
 /* ON/OFF toggle */
 .adv-toggle-group {
   display: flex;
@@ -717,6 +725,7 @@ input[type="number"]::-webkit-outer-spin-button {
 
 .adv-sequence-toolbar {
   display: flex;
+  gap: 8px;
   justify-content: flex-end;
   width: 100%;
   flex-shrink: 0;
@@ -969,6 +978,38 @@ input[type="number"]::-webkit-outer-spin-button {
 
 .adv-sequence-clicks {
   min-width: 0;
+}
+
+.adv-sequence-item--key {
+  grid-template-columns:
+    28px minmax(5.5rem, 1fr) minmax(5.5rem, auto) minmax(5.75rem, auto)
+    auto;
+}
+
+.adv-sequence-item--key .adv-sequence-clicks {
+  min-width: 5.75rem;
+}
+
+.adv-sequence-hold {
+  min-width: 5.5rem;
+}
+
+.adv-sequence-key-target {
+  width: auto;
+  min-width: 0;
+  height: 28px;
+  overflow: hidden;
+}
+
+.adv-sequence-key-target .adv-key-input {
+  flex: 1 1 auto;
+  width: 0;
+  min-width: 0;
+  font-size: 0.75rem;
+}
+
+.adv-sequence-key-target .hk-button {
+  max-width: 100%;
 }
 
 .adv-sequence-actions,

--- a/src/components/panels/advanced/DutyCycleSection.tsx
+++ b/src/components/panels/advanced/DutyCycleSection.tsx
@@ -1,6 +1,10 @@
 import type { Settings } from "../../../store";
 
-import { SETTINGS_LIMITS } from "../../../settingsSchema";
+import {
+  hasKeyOnlySequenceActions,
+  SETTINGS_LIMITS,
+} from "../../../settingsSchema";
+import UnavailableReason from "../../UnavailableReason";
 import { InfoIcon, NumInput } from "./shared";
 
 interface Props {
@@ -14,6 +18,10 @@ export default function DutyCycleSection({
   update,
   showInfo,
 }: Props) {
+  const clickDurationDisabled = hasKeyOnlySequenceActions(settings);
+  const disabledReason =
+    "Key sequence actions use each row's hold ms value instead of Click Duration.";
+
   return (
     <div className="adv-sectioncontainer adv-basic-card">
       <div className="adv-card-header">
@@ -30,17 +38,26 @@ export default function DutyCycleSection({
           <span className="adv-card-title">Click Duration</span>
         </div>
         <div className="adv-row" style={{ gap: 6 }}>
-          <div className="adv-minmax">
-            <div className="adv-numbox-sm">
-              <NumInput
-                value={settings.dutyCycle}
-                onChange={(v) => update({ dutyCycle: v })}
-                min={SETTINGS_LIMITS.dutyCycle.min}
-                max={SETTINGS_LIMITS.dutyCycle.max}
-              />
-              <span className="adv-unit">%</span>
+          <UnavailableReason
+            reason={clickDurationDisabled ? disabledReason : undefined}
+          >
+            <div
+              className={`adv-minmax ${
+                clickDurationDisabled ? "adv-control-disabled" : ""
+              }`}
+            >
+              <div className="adv-numbox-sm">
+                <NumInput
+                  value={settings.dutyCycle}
+                  onChange={(v) => update({ dutyCycle: v })}
+                  min={SETTINGS_LIMITS.dutyCycle.min}
+                  max={SETTINGS_LIMITS.dutyCycle.max}
+                  disabled={clickDurationDisabled}
+                />
+                <span className="adv-unit">%</span>
+              </div>
             </div>
-          </div>
+          </UnavailableReason>
         </div>
       </div>
     </div>

--- a/src/components/panels/advanced/SequenceSection.tsx
+++ b/src/components/panels/advanced/SequenceSection.tsx
@@ -7,7 +7,14 @@ import {
 } from "react";
 import { error } from "@tauri-apps/plugin-log";
 import { getEffectiveIntervalMs } from "../../../cadence";
+import { conflictsWithAutoPressKey } from "../../../hotkeys";
+import { isAlphabeticKeyboardKey } from "../../../keyboardKeyCase";
+import {
+  DEFAULT_SEQUENCE_KEY_HOLD_MS,
+  SETTINGS_LIMITS,
+} from "../../../settingsSchema";
 import type { SequencePoint, Settings } from "../../../store";
+import KeyCaptureInput from "../../KeyCaptureInput";
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -53,6 +60,21 @@ function createSequencePointId(): string {
     globalThis.crypto?.randomUUID?.() ??
     `seq-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
   );
+}
+
+function isMouseSequencePoint(point: SequencePoint) {
+  return point.action !== "key";
+}
+
+function createKeySequencePoint(settings: Settings): SequencePoint {
+  return {
+    id: createSequencePointId(),
+    action: "key",
+    key: settings.keyboardKey,
+    keyCase: settings.keyboardKeyCase,
+    holdMs: DEFAULT_SEQUENCE_KEY_HOLD_MS,
+    clicks: 1,
+  };
 }
 
 function reorderSequencePoints(
@@ -116,15 +138,14 @@ export default function SequenceSection({
     void listen<SequencePointPickedPayload>(
       "sequence-point-picked",
       (event) => {
-        const nextPoints = [
-          ...latestPointsRef.current,
-          {
-            id: createSequencePointId(),
-            x: event.payload.x,
-            y: event.payload.y,
-            clicks: 1,
-          },
-        ];
+        const nextPoint: SequencePoint = {
+          id: createSequencePointId(),
+          action: "mouse",
+          x: event.payload.x,
+          y: event.payload.y,
+          clicks: 1,
+        };
+        const nextPoints = [...latestPointsRef.current, nextPoint];
         latestPointsRef.current = nextPoints;
         updateRef.current({
           sequenceEnabled: true,
@@ -151,6 +172,14 @@ export default function SequenceSection({
         let nearestDistanceSquared = Number.POSITIVE_INFINITY;
 
         latestPointsRef.current.forEach((point, index) => {
+          if (
+            !isMouseSequencePoint(point) ||
+            typeof point.x !== "number" ||
+            typeof point.y !== "number"
+          ) {
+            return;
+          }
+
           const dx = point.x - event.payload.x;
           const dy = point.y - event.payload.y;
           const distanceSquared = dx * dx + dy * dy;
@@ -265,6 +294,16 @@ export default function SequenceSection({
       (_: SequencePoint, pointIndex: number) => pointIndex !== index,
     );
     update({ sequencePoints: nextPoints });
+  };
+
+  const addSequenceKey = () => {
+    update({
+      sequenceEnabled: true,
+      sequencePoints: [
+        ...settings.sequencePoints,
+        createKeySequencePoint(settings),
+      ],
+    });
   };
 
   const updateBottomFade = useCallback(() => {
@@ -475,9 +514,9 @@ export default function SequenceSection({
           }}
         >
           {showInfo ? (
-            <InfoIcon text="Cycles through saved cursor positions in round-robin order, applying the current global timing and click settings at each point." />
+            <InfoIcon text="Cycles through saved mouse and key steps in round-robin order, applying the current global timing settings to each step." />
           ) : null}
-          <span className="adv-card-title">Sequence Clicking</span>
+          <span className="adv-card-title">Sequence Actions</span>
         </div>
         <ToggleBtn
           value={settings.sequenceEnabled}
@@ -495,22 +534,31 @@ export default function SequenceSection({
       <Disableable enabled={settings.sequenceEnabled}>
         <div className="adv-sequence-body">
           <div className="adv-sequence-controls">
-            <button
-              type="button"
-              className="adv-secondary-btn"
-              onClick={() => {
-                void (pickingSequence
-                  ? cancelSequencePointPick()
-                  : startSequencePointPick());
-              }}
-            >
-              {pickingSequence ? "Cancel Picking" : "Start Picking"}
-            </button>
+            <div className="adv-sequence-toolbar">
+              <button
+                type="button"
+                className="adv-secondary-btn"
+                onClick={() => {
+                  void (pickingSequence
+                    ? cancelSequencePointPick()
+                    : startSequencePointPick());
+                }}
+              >
+                {pickingSequence ? "Cancel Picking" : "Pick Mouse"}
+              </button>
+              <button
+                type="button"
+                className="adv-secondary-btn"
+                onClick={addSequenceKey}
+              >
+                Add Key
+              </button>
+            </div>
             <div className="adv-sequence-list-shell">
               <div ref={listViewportRef} className="adv-sequence-list">
                 {settings.sequencePoints.length === 0 ? (
                   <div className="adv-sequence-empty">
-                    No sequence points saved yet.
+                    No sequence steps saved yet.
                   </div>
                 ) : (
                   settings.sequencePoints.map(
@@ -520,6 +568,21 @@ export default function SequenceSection({
                         1,
                         point.clicks * getEffectiveIntervalMs(settings),
                       );
+                      const isKeyStep = point.action === "key";
+                      const keyCase = point.keyCase ?? "lower";
+                      const keyCaseIsUpper = keyCase === "upper";
+                      const holdMs =
+                        point.holdMs ?? DEFAULT_SEQUENCE_KEY_HOLD_MS;
+                      const canToggleKeyCase = isAlphabeticKeyboardKey(
+                        point.key ?? "",
+                      );
+                      const keyConflicts =
+                        isKeyStep &&
+                        conflictsWithAutoPressKey(
+                          settings.hotkey,
+                          point.key ?? "",
+                          keyCaseIsUpper,
+                        );
 
                       return (
                         <div
@@ -535,7 +598,9 @@ export default function SequenceSection({
                             draggingId === point.id
                               ? "adv-sequence-item--dragging"
                               : ""
-                          } ${isActive ? "adv-sequence-item--active" : ""}`}
+                          } ${isActive ? "adv-sequence-item--active" : ""} ${
+                            isKeyStep ? "adv-sequence-item--key" : ""
+                          }`}
                           style={
                             isActive
                               ? ({
@@ -589,83 +654,215 @@ export default function SequenceSection({
                               </svg>
                             </button>
                           </div>
-                          <label
-                            className="adv-numbox-sm adv-sequence-coord adv-sequence-position"
-                            style={{ gap: "6px" }}
-                          >
-                            <span
-                              className="adv-unit"
-                              style={{
-                                minWidth: "0.125rem",
-                                textAlign: "center",
-                              }}
-                            >
-                              X
-                            </span>
-                            <NumInput
-                              hoverWheel={false}
-                              value={point.x}
-                              onChange={(value) =>
-                                updateSequencePoint(index, { x: value })
-                              }
-                              style={{
-                                flex: 1,
-                                width: "100%",
-                                textAlign: "right",
-                              }}
-                            />
-                          </label>
-                          <label
-                            className="adv-numbox-sm adv-sequence-coord adv-sequence-position"
-                            style={{ gap: "6px" }}
-                          >
-                            <span
-                              className="adv-unit"
-                              style={{
-                                minWidth: "0.125rem",
-                                textAlign: "left",
-                              }}
-                            >
-                              Y
-                            </span>
-                            <NumInput
-                              hoverWheel={false}
-                              value={point.y}
-                              onChange={(value) =>
-                                updateSequencePoint(index, { y: value })
-                              }
-                              style={{
-                                flex: 1,
-                                width: "100%",
-                                textAlign: "right",
-                              }}
-                            />
-                          </label>
-                          <label
-                            className="adv-numbox-sm adv-sequence-coord adv-sequence-clicks"
-                            style={{ gap: "6px" }}
-                          >
-                            <span
-                              className="adv-unit"
-                              style={{ minWidth: "0.75rem", textAlign: "left" }}
-                            >
-                              clicks
-                            </span>
-                            <NumInput
-                              hoverWheel={false}
-                              value={point.clicks}
-                              min={1}
-                              max={100000}
-                              onChange={(value) =>
-                                updateSequencePoint(index, { clicks: value })
-                              }
-                              style={{
-                                flex: 1,
-                                width: "100%",
-                                textAlign: "right",
-                              }}
-                            />
-                          </label>
+                          {isKeyStep ? (
+                            <>
+                              <div className="adv-textbox adv-sequence-key-target">
+                                <KeyCaptureInput
+                                  className="adv-textbox-text adv-key-input"
+                                  value={point.key ?? ""}
+                                  onChange={(key) =>
+                                    updateSequencePoint(index, {
+                                      action: "key",
+                                      key,
+                                    })
+                                  }
+                                  keyboardKeyCase={keyCase}
+                                  style={{
+                                    background: "transparent",
+                                    border: "none",
+                                    outline: "none",
+                                  }}
+                                  conflicts={keyConflicts ? ["Hotkey"] : []}
+                                />
+                                <button
+                                  type="button"
+                                  className={`adv-key-case-toggle ${
+                                    keyCaseIsUpper
+                                      ? "adv-key-case-toggle--upper"
+                                      : "adv-key-case-toggle--lower"
+                                  }`}
+                                  aria-label={
+                                    keyCaseIsUpper
+                                      ? "Send letters as uppercase"
+                                      : "Send letters as lowercase"
+                                  }
+                                  aria-pressed={keyCaseIsUpper}
+                                  title="Toggle keyboard key case"
+                                  disabled={!canToggleKeyCase}
+                                  onClick={() =>
+                                    updateSequencePoint(index, {
+                                      keyCase: keyCaseIsUpper
+                                        ? "lower"
+                                        : "upper",
+                                    })
+                                  }
+                                >
+                                  {keyCaseIsUpper ? "A" : "a"}
+                                </button>
+                              </div>
+                              <label
+                                className="adv-numbox-sm adv-sequence-coord adv-sequence-hold"
+                                style={{ gap: "6px" }}
+                              >
+                                <span
+                                  className="adv-unit"
+                                  style={{
+                                    minWidth: "0.75rem",
+                                    textAlign: "left",
+                                  }}
+                                >
+                                  hold
+                                </span>
+                                <NumInput
+                                  hoverWheel={false}
+                                  value={holdMs}
+                                  min={SETTINGS_LIMITS.sequenceKeyHoldMs.min}
+                                  max={SETTINGS_LIMITS.sequenceKeyHoldMs.max}
+                                  onChange={(value) =>
+                                    updateSequencePoint(index, {
+                                      holdMs: value,
+                                    })
+                                  }
+                                  style={{
+                                    flex: 1,
+                                    width: "100%",
+                                    textAlign: "right",
+                                  }}
+                                />
+                                <span
+                                  className="adv-unit"
+                                  style={{
+                                    marginLeft: 0,
+                                    minWidth: "1rem",
+                                    textAlign: "left",
+                                  }}
+                                >
+                                  ms
+                                </span>
+                              </label>
+                              <label
+                                className="adv-numbox-sm adv-sequence-coord adv-sequence-clicks"
+                                style={{ gap: "6px" }}
+                              >
+                                <span
+                                  className="adv-unit"
+                                  style={{
+                                    minWidth: "0.75rem",
+                                    textAlign: "left",
+                                  }}
+                                >
+                                  presses
+                                </span>
+                                <NumInput
+                                  hoverWheel={false}
+                                  value={point.clicks}
+                                  min={1}
+                                  max={100000}
+                                  onChange={(value) =>
+                                    updateSequencePoint(index, {
+                                      clicks: value,
+                                    })
+                                  }
+                                  style={{
+                                    flex: 1,
+                                    width: "100%",
+                                    textAlign: "right",
+                                  }}
+                                />
+                              </label>
+                            </>
+                          ) : (
+                            <>
+                              <label
+                                className="adv-numbox-sm adv-sequence-coord adv-sequence-position"
+                                style={{ gap: "6px" }}
+                              >
+                                <span
+                                  className="adv-unit"
+                                  style={{
+                                    minWidth: "0.125rem",
+                                    textAlign: "center",
+                                  }}
+                                >
+                                  X
+                                </span>
+                                <NumInput
+                                  hoverWheel={false}
+                                  value={point.x ?? 0}
+                                  onChange={(value) =>
+                                    updateSequencePoint(index, {
+                                      action: "mouse",
+                                      x: value,
+                                    })
+                                  }
+                                  style={{
+                                    flex: 1,
+                                    width: "100%",
+                                    textAlign: "right",
+                                  }}
+                                />
+                              </label>
+                              <label
+                                className="adv-numbox-sm adv-sequence-coord adv-sequence-position"
+                                style={{ gap: "6px" }}
+                              >
+                                <span
+                                  className="adv-unit"
+                                  style={{
+                                    minWidth: "0.125rem",
+                                    textAlign: "left",
+                                  }}
+                                >
+                                  Y
+                                </span>
+                                <NumInput
+                                  hoverWheel={false}
+                                  value={point.y ?? 0}
+                                  onChange={(value) =>
+                                    updateSequencePoint(index, {
+                                      action: "mouse",
+                                      y: value,
+                                    })
+                                  }
+                                  style={{
+                                    flex: 1,
+                                    width: "100%",
+                                    textAlign: "right",
+                                  }}
+                                />
+                              </label>
+                              <label
+                                className="adv-numbox-sm adv-sequence-coord adv-sequence-clicks"
+                                style={{ gap: "6px" }}
+                              >
+                                <span
+                                  className="adv-unit"
+                                  style={{
+                                    minWidth: "0.75rem",
+                                    textAlign: "left",
+                                  }}
+                                >
+                                  clicks
+                                </span>
+                                <NumInput
+                                  hoverWheel={false}
+                                  value={point.clicks}
+                                  min={1}
+                                  max={100000}
+                                  onChange={(value) =>
+                                    updateSequencePoint(index, {
+                                      clicks: value,
+                                    })
+                                  }
+                                  style={{
+                                    flex: 1,
+                                    width: "100%",
+                                    textAlign: "right",
+                                  }}
+                                />
+                              </label>
+                            </>
+                          )}
                           <div className="adv-sequence-actions">
                             <button
                               type="button"

--- a/src/components/panels/advanced/shared.tsx
+++ b/src/components/panels/advanced/shared.tsx
@@ -112,6 +112,7 @@ export function NumInput({
   max,
   style,
   hoverWheel = true,
+  disabled = false,
 }: {
   value: number;
   onChange: (v: number) => void;
@@ -119,6 +120,7 @@ export function NumInput({
   max?: number;
   style?: CSSProperties;
   hoverWheel?: boolean;
+  disabled?: boolean;
 }) {
   const ref = useRef<HTMLInputElement>(null);
   const wheelRef = useRef(false);
@@ -130,6 +132,9 @@ export function NumInput({
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (disabled) {
+      return;
+    }
     if (wheelRef.current) {
       if (ref.current) ref.current.value = String(value);
       return;
@@ -143,6 +148,9 @@ export function NumInput({
   };
 
   const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
+    if (disabled) {
+      return;
+    }
     const raw = normalizeIntegerRaw(e.target.value);
     if (raw !== e.target.value) {
       e.target.value = raw;
@@ -153,6 +161,9 @@ export function NumInput({
   };
 
   const handleWheel = (e: WheelEvent<HTMLInputElement>) => {
+    if (disabled) {
+      return;
+    }
     if (!hoverWheel && e.target !== document.activeElement) return;
     e.preventDefault();
     const direction = e.deltaY < 0 ? 1 : -1;
@@ -175,6 +186,7 @@ export function NumInput({
       value={value}
       min={min}
       max={max}
+      disabled={disabled}
       onChange={handleChange}
       onBlur={handleBlur}
       onWheel={handleWheel}

--- a/src/settingsSchema.ts
+++ b/src/settingsSchema.ts
@@ -17,15 +17,21 @@ export interface ProcessListEntry {
   enabled: boolean;
 }
 export type AdvancedSequenceLayout = "wide" | "tall";
+export type SequenceActionType = "mouse" | "key";
 
 export interface SequencePoint {
   id: string;
-  x: number;
-  y: number;
+  action: SequenceActionType;
+  x?: number;
+  y?: number;
+  key?: string;
+  keyCase?: KeyboardKeyCase;
+  holdMs?: number;
   clicks: number;
 }
 
 export const DEFAULT_ACCENT_COLOR = "#22c55e";
+export const DEFAULT_SEQUENCE_KEY_HOLD_MS = 30;
 export const MAX_PRESETS = 20;
 export const PRESET_NAME_MAX_LENGTH = 40;
 export const DEFAULT_MAX_CLICK_SPEED = 500;
@@ -434,6 +440,16 @@ export type Settings = PresetFieldValues &
     version: string;
   };
 
+export function hasKeyOnlySequenceActions(
+  settings: Pick<Settings, "sequenceEnabled" | "sequencePoints">,
+): boolean {
+  return (
+    settings.sequenceEnabled &&
+    settings.sequencePoints.length > 0 &&
+    settings.sequencePoints.every((point) => point.action === "key")
+  );
+}
+
 export const PRESET_SNAPSHOT_KEYS = Object.keys(PRESET_FIELDS) as ReadonlyArray<
   keyof PresetSnapshot
 >;
@@ -449,6 +465,7 @@ export const SETTINGS_LIMITS = {
   position: SETTINGS_ONLY_FIELDS.customStopZoneX.limit,
   stopZoneDimension: SETTINGS_ONLY_FIELDS.customStopZoneWidth.limit,
   sequencePointClicks: { min: 1, max: 100000 },
+  sequenceKeyHoldMs: { min: 1, max: 5000 },
 };
 
 export const SETTINGS_UI_SCHEMA = [
@@ -619,13 +636,56 @@ function sanitizeSequencePoints(value: unknown): SequencePoint[] {
   if (!Array.isArray(value)) return [];
 
   return value
-    .map((point) => {
+    .map((point): SequencePoint | null => {
       if (!point || typeof point !== "object") return null;
       const candidate = point as Partial<SequencePoint>;
       const id =
         typeof candidate.id === "string" && candidate.id.trim()
           ? candidate.id.trim()
           : createSequencePointId();
+      const action: SequenceActionType =
+        candidate.action === "key" ? "key" : "mouse";
+      const clicks =
+        typeof candidate.clicks === "number" &&
+        Number.isFinite(candidate.clicks)
+          ? Math.trunc(candidate.clicks)
+          : 1;
+      const safeClicks = clampNumber(
+        clicks,
+        1,
+        SETTINGS_LIMITS.sequencePointClicks.min,
+        SETTINGS_LIMITS.sequencePointClicks.max,
+      );
+
+      if (action === "key") {
+        const key =
+          typeof candidate.key === "string" ? candidate.key.trim() : "";
+        const keyCase = sanitizeEnum(
+          candidate.keyCase,
+          "lower" as KeyboardKeyCase,
+          ["lower", "upper"],
+        );
+        const holdMs =
+          typeof candidate.holdMs === "number" &&
+          Number.isFinite(candidate.holdMs)
+            ? Math.trunc(candidate.holdMs)
+            : DEFAULT_SEQUENCE_KEY_HOLD_MS;
+
+        return {
+          id,
+          action,
+          key,
+          keyCase,
+          holdMs: clampNumber(
+            holdMs,
+            DEFAULT_SEQUENCE_KEY_HOLD_MS,
+            SETTINGS_LIMITS.sequenceKeyHoldMs.min,
+            SETTINGS_LIMITS.sequenceKeyHoldMs.max,
+          ),
+          clicks: safeClicks,
+        };
+      }
+
       const x =
         typeof candidate.x === "number" && Number.isFinite(candidate.x)
           ? Math.trunc(candidate.x)
@@ -634,24 +694,15 @@ function sanitizeSequencePoints(value: unknown): SequencePoint[] {
         typeof candidate.y === "number" && Number.isFinite(candidate.y)
           ? Math.trunc(candidate.y)
           : null;
-      const clicks =
-        typeof candidate.clicks === "number" &&
-        Number.isFinite(candidate.clicks)
-          ? Math.trunc(candidate.clicks)
-          : 1;
 
       if (x === null || y === null) return null;
 
       return {
         id,
+        action,
         x,
         y,
-        clicks: clampNumber(
-          clicks,
-          1,
-          SETTINGS_LIMITS.sequencePointClicks.min,
-          SETTINGS_LIMITS.sequencePointClicks.max,
-        ),
+        clicks: safeClicks,
       };
     })
     .filter((point): point is SequencePoint => point !== null);

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,6 +22,7 @@ export type {
   PresetSnapshot,
   RateInputMode,
   SavedPanel,
+  SequenceActionType,
   SequencePoint,
   Settings,
   Theme,


### PR DESCRIPTION
## Summary

- Add keyboard steps to Sequence Actions so sequences can round-robin through mouse clicks and key presses.
- Add per-key hold duration and press count controls for key sequence rows.
- Disable Click Duration when the enabled sequence contains only key actions, since key rows use their own hold duration.
- Keep legacy mouse sequence points compatible and hide key-only rows from the mouse overlay.

## Screenshot

<img width="1140" height="660" alt="image" src="https://github.com/user-attachments/assets/2d9927d4-640a-401e-8a1e-e3648468b4f6" />

## Related issue

N/A

## Testing

- `cargo test --manifest-path src-tauri\Cargo.toml`
- `npm test`
- `npm run lint`
- `npm run frontend:build`
- `cargo check --manifest-path src-tauri\Cargo.toml --locked`
- `cargo clippy --manifest-path src-tauri\Cargo.toml`
- `cargo fmt --manifest-path src-tauri\Cargo.toml --check`
- `npm audit`