### PR TITLE
Keep disabled process-list entries visible so they can be removed

### DIFF
--- a/src/components/panels/zones/sections/ProcessListSection.tsx
+++ b/src/components/panels/zones/sections/ProcessListSection.tsx
@@ -66,16 +66,19 @@ export default function ProcessListSection({
   }, [silentRefresh]);
 
   const toggleEntry = (name: string, checked: boolean) => {
+    const withoutName = settings.processListEntries.filter(
+      (e) => e.name !== name,
+    );
     const next = checked
       ? [
-          ...settings.processListEntries,
+          ...withoutName,
           {
             name,
             behavior: "stop" as ProcessListBehavior,
             enabled: true,
           } as ProcessListEntry,
         ]
-      : settings.processListEntries.filter((e) => e.name !== name);
+      : withoutName;
     update({ processListEntries: next });
   };
 
@@ -96,7 +99,7 @@ export default function ProcessListSection({
     (p) => entryMap.get(p.name)?.enabled && matchesSearch(p),
   );
   const uncheckedProcesses = processes.filter(
-    (p) => !entryMap.has(p.name) && matchesSearch(p),
+    (p) => !entryMap.get(p.name)?.enabled && matchesSearch(p),
   );
 
   return (


### PR DESCRIPTION
## Summary

A process-list entry saved as disabled (`enabled: false`) showed in neither list, so its row vanished and couldn't be re-enabled or removed. Now it shows as an unchecked row, and re-checking no longer leaves a duplicate.

## Related issue(s)

N/A

## Change type

- [x] Bug fix

## Screenshots (if applicable)

—

## Validation

`npm run lint`, `npx tsc -b`, `npm test` (9/9) — all passed. My lines are Prettier-clean.

## Checklist

- [x] I ran `npm run check:all` and it passed with no errors
- [x] I kept the change focused and avoided unrelated refactors
- [x] I updated related documentation when needed
