### PR TITLE
Fix four small bugs found while reading the code

### DIFF
--- a/src-tauri/src/crash_handler.rs
+++ b/src-tauri/src/crash_handler.rs
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "crashpad"))]
     fn crashpad_stub_returns_ok() {
-        let result = initialize_crashpad();
+        let result = super::initialize_crashpad();
         assert!(result.is_ok());
     }
 }

--- a/src-tauri/src/engine/rng.rs
+++ b/src-tauri/src/engine/rng.rs
@@ -10,7 +10,7 @@ impl SmallRng {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.subsec_nanos() as u64 ^ d.as_secs())
             .unwrap_or(12345);
-        let seed = t ^ (std::process::id() as u64).wrapping_mul(0x9e3779b97f4a7c15);
+        let seed = (t ^ (std::process::id() as u64).wrapping_mul(0x9e3779b97f4a7c15)) | 1;
         Self {
             state: seed,
             cached_gaussian: None,

--- a/src/components/panels/settings/sections/PresetsSection.tsx
+++ b/src/components/panels/settings/sections/PresetsSection.tsx
@@ -282,7 +282,9 @@ export default function PresetsSection({
           </button>
         </div>
         {presetLimitReached && (
-          <span className="settings-note">Max 6 presets allowed</span>
+          <span className="settings-note">
+            Max {MAX_PRESETS} presets allowed
+          </span>
         )}
         {running && (
           <span className="settings-note">Disabled while clicking</span>

--- a/src/settingsSchema.ts
+++ b/src/settingsSchema.ts
@@ -735,6 +735,11 @@ function sanitizePresetSnapshot(
     defaults.timeLimitUnit,
     TIME_LIMIT_UNIT_OPTIONS,
   );
+  snapshot.processListMode = sanitizeEnum(
+    saved.processListMode,
+    defaults.processListMode,
+    ["whitelist", "blacklist"],
+  );
   snapshot.sequencePoints = sanitizeSequencePoints(saved.sequencePoints);
   snapshot.processListEntries = sanitizeProcessListEntries(
     saved.processListEntries,
@@ -833,6 +838,11 @@ export function sanitizeSettings(
     saved.timeLimitUnit,
     defaults.timeLimitUnit,
     TIME_LIMIT_UNIT_OPTIONS,
+  );
+  presetSettings.processListMode = sanitizeEnum(
+    saved.processListMode,
+    defaults.processListMode,
+    ["whitelist", "blacklist"],
   );
   presetSettings.sequencePoints = sanitizeSequencePoints(saved.sequencePoints);
   presetSettings.processListEntries = sanitizeProcessListEntries(


### PR DESCRIPTION
## Summary

Four small, unrelated fixes, one commit each:

- `rng.rs` — the RNG seed could be 0, which freezes the generator (returns 0 forever) and kills all timing/jitter randomness. Force it non-zero.
- `settingsSchema.ts` — `processListMode` wasn't validated on load, so a bad saved value could leave the whitelist/blacklist toggle with neither option on. Validate it.
- `PresetsSection.tsx` — the preset limit note said "Max 6" but the real limit is 20. Use the real number.
- `crash_handler.rs` — a test didn't compile under `--no-default-features` (missing `super::`). Qualify it.

## Related issue(s)

N/A

## Change type

- [x] Bug fix

## Screenshots (if applicable)

Preset note now reads "Max 20 presets allowed".

## Validation

`cargo fmt/clippy/test` (73/73) and `npm lint/tsc/test` (9/9) — all passed. My lines Prettier-clean.

## Checklist

- [x] I ran `npm run check:all` and it passed with no errors
- [x] I kept the change focused and avoided unrelated refactors
- [x] I updated related documentation when needed
