### PR TITLE
Stop clicking right away when a failsafe triggers mid-hold

### DIFF
--- a/src-tauri/src/engine/keyboard.rs
+++ b/src-tauri/src/engine/keyboard.rs
@@ -120,8 +120,8 @@ pub fn send_key_presses(
     }
 
     let use_shift = should_hold_shift_for_case(vk, uppercase);
-    let is_active = || control.is_active();
-    let mut sleep_for = |duration| sleep_interruptible(duration, control);
+    let is_active = || control.is_active() && !should_abort();
+    let mut sleep_for = |duration| sleep_interruptible(duration, control, should_abort);
 
     for _ in 0..count {
         if should_abort() {

--- a/src-tauri/src/engine/mouse.rs
+++ b/src-tauri/src/engine/mouse.rs
@@ -240,8 +240,8 @@ pub fn send_clicks(
         return;
     }
 
-    let is_active = || control.is_active();
-    let mut sleep_for = |duration| sleep_interruptible(duration, control);
+    let is_active = || control.is_active() && !should_abort();
+    let mut sleep_for = |duration| sleep_interruptible(duration, control, should_abort);
 
     for _ in 0..count {
         if should_abort() {

--- a/src-tauri/src/engine/worker.rs
+++ b/src-tauri/src/engine/worker.rs
@@ -747,7 +747,7 @@ fn run_batch(
 
     let sleep_dur = st.next_batch_time.saturating_duration_since(Instant::now());
     if sleep_dur > Duration::ZERO {
-        sleep_interruptible(sleep_dur, control);
+        sleep_interruptible(sleep_dur, control, should_abort);
     }
 
     if config.use_sequence() {
@@ -845,10 +845,14 @@ pub fn get_click_count() -> i64 {
     CLICK_COUNT.load(Ordering::Relaxed)
 }
 
-pub fn sleep_interruptible(remaining: Duration, control: &RunControl) {
+pub fn sleep_interruptible(
+    remaining: Duration,
+    control: &RunControl,
+    should_abort: &dyn Fn() -> bool,
+) {
     let tick = Duration::from_millis(5);
     let start = Instant::now();
-    while control.is_active() && start.elapsed() < remaining {
+    while control.is_active() && !should_abort() && start.elapsed() < remaining {
         let left = remaining.saturating_sub(start.elapsed());
         std::thread::sleep(left.min(tick));
     }


### PR DESCRIPTION
## Summary

Failsafes (stop zone, corner/edge, Alt+Tab, process-list stop, time limit) were only checked between clicks. If one triggered mid-hold, the click kept holding to the end (up to ~1s on low CPS + high duty), so the button stayed down in the stop zone. Now the check also runs during the hold and the wait, so it lets go within ~5 ms. `cycle.rs` unchanged.

## Related issue(s)

N/A

## Change type

- [x] Bug fix

## Screenshots (if applicable)

—

## Validation

`cargo fmt --check`, `cargo clippy`, `cargo test` (73/73) — all passed. Frontend not touched.

## Checklist

- [x] I ran `npm run check:all` and it passed with no errors
- [x] I kept the change focused and avoided unrelated refactors
- [x] I updated related documentation when needed
