### PR TITLE
Fix seven small bugs I found while reading the code

### DIFF
--- a/src-tauri/src/crash_handler.rs
+++ b/src-tauri/src/crash_handler.rs
@@ -12,8 +12,8 @@ pub fn initialize_crashpad() -> Result<(), Box<dyn std::error::Error>> {
     let handler_path = resolve_handler_path()?;
 
     let config = crashpad_rs::CrashpadConfig::builder()
-        .handler_path(handler_path.to_str().unwrap())
-        .database_path(crash_database.to_str().unwrap())
+        .handler_path(&handler_path)
+        .database_path(&crash_database)
         .build();
 
     client.start_with_config(&config, &std::collections::HashMap::new())?;

--- a/src-tauri/src/engine/worker.rs
+++ b/src-tauri/src/engine/worker.rs
@@ -227,6 +227,7 @@ pub fn stop_clicker_inner(
 ) -> AppResult<ClickerStatusPayload> {
     let state = app.state::<ClickerState>();
     let was_running = state.running.swap(false, Ordering::SeqCst);
+    state.paused.store(false, Ordering::SeqCst);
     state.active_sequence_index.store(-1, Ordering::SeqCst);
     state.active_sequence_tick.store(0, Ordering::SeqCst);
     if was_running {

--- a/src-tauri/src/window_lifecycle.rs
+++ b/src-tauri/src/window_lifecycle.rs
@@ -2,7 +2,7 @@ use tauri::AppHandle;
 
 #[cfg(target_os = "windows")]
 fn trim_webview_processes() {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::System::Diagnostics::ToolHelp::*;
@@ -51,12 +51,15 @@ fn trim_webview_processes() {
         CloseHandle(snapshot);
 
         let mut descendant_pids: Vec<u32> = Vec::new();
+        let mut visited: HashSet<u32> = HashSet::from([our_pid]);
         let mut queue: Vec<u32> = vec![our_pid];
         while let Some(pid) = queue.pop() {
             if let Some(children) = children_of.get(&pid) {
                 for &child in children {
-                    descendant_pids.push(child);
-                    queue.push(child);
+                    if visited.insert(child) {
+                        descendant_pids.push(child);
+                        queue.push(child);
+                    }
                 }
             }
         }

--- a/src/components/panels/advanced/sections/LimitsSection.tsx
+++ b/src/components/panels/advanced/sections/LimitsSection.tsx
@@ -23,9 +23,11 @@ export default function LimitsSection({ settings, update, showInfo }: Props) {
       : mode;
 
   const updateRef = useRef(update);
+  const isClicksModeRef = useRef(effectiveMode === "clicks");
 
   useLayoutEffect(() => {
     updateRef.current = update;
+    isClicksModeRef.current = effectiveMode === "clicks";
   });
 
   useEffect(() => {
@@ -63,7 +65,7 @@ export default function LimitsSection({ settings, update, showInfo }: Props) {
   };
 
   const handleToggleChange = (nextValue: boolean) => {
-    if (isClicksMode) {
+    if (isClicksModeRef.current) {
       update({
         clickLimitEnabled: nextValue,
         timeLimitEnabled: false,

--- a/src/components/panels/settings/sections/GeneralSection.tsx
+++ b/src/components/panels/settings/sections/GeneralSection.tsx
@@ -41,7 +41,7 @@ function formatCpu(
   language: string,
   notAvailable: string,
 ): string {
-  if (cpu < 0) return notAvailable;
+  if (!Number.isFinite(cpu) || cpu < 0) return notAvailable;
   return `${cpu.toLocaleString(language, {
     minimumFractionDigits: 1,
     maximumFractionDigits: 1,

--- a/src/numberInput.ts
+++ b/src/numberInput.ts
@@ -4,6 +4,8 @@ export function normalizeIntegerRaw(raw: string) {
   }
 
   const negative = raw.startsWith("-");
-  const digits = (negative ? raw.slice(1) : raw).replace(/^0+(?=\d)/, "");
+  const digits = (negative ? raw.slice(1) : raw)
+    .replace(/\D.*$/s, "")
+    .replace(/^0+(?=\d)/, "");
   return `${negative ? "-" : ""}${digits}`;
 }

--- a/src/settingsSchema.ts
+++ b/src/settingsSchema.ts
@@ -31,6 +31,9 @@ export const PRESET_NAME_MAX_LENGTH = 40;
 export const DEFAULT_MAX_CLICK_SPEED = 500;
 export const EXTENDED_MAX_CLICK_SPEED = 1000;
 
+const INT32_MIN = -2147483648;
+const INT32_MAX = 2147483647;
+
 export const CLICK_INTERVAL_OPTIONS = [
   { value: "s", label: "Second" },
   { value: "m", label: "Minute" },
@@ -628,11 +631,11 @@ function sanitizeSequencePoints(value: unknown): SequencePoint[] {
           : createSequencePointId();
       const x =
         typeof candidate.x === "number" && Number.isFinite(candidate.x)
-          ? Math.trunc(candidate.x)
+          ? clampNumber(Math.trunc(candidate.x), 0, INT32_MIN, INT32_MAX)
           : null;
       const y =
         typeof candidate.y === "number" && Number.isFinite(candidate.y)
-          ? Math.trunc(candidate.y)
+          ? clampNumber(Math.trunc(candidate.y), 0, INT32_MIN, INT32_MAX)
           : null;
       const clicks =
         typeof candidate.clicks === "number" &&


### PR DESCRIPTION
## Summary

Seven small, unrelated fixes, one commit each:

- `window_lifecycle.rs` — the ~30s process-trim walk had no "seen" set; PID reuse can loop the process tree, so it ran forever and allocated until the app crashed. Added a seen-set.
- `LimitsSection.tsx` — the cached Limits toggle kept a stale handler after a Click/Time switch, so turning it on enabled the wrong limit. Read the current mode from a ref.
- `crash_handler.rs` — `.unwrap()` on a non-UTF-8 `%LOCALAPPDATA%` path crashed startup. Pass the path directly.
- `GeneralSection.tsx` — a null CPU value from a broken stats file crashed the app; now falls back to "N/A".
- `numberInput.ts` — integer boxes accepted `7.5`/`1e3`, which the backend rejected, silently stopping settings from saving. Whole numbers only now.
- `settingsSchema.ts` — an out-of-range sequence X/Y overflowed the backend's i32 and made it reject every setting (incl. failsafe zones). Clamp X/Y.
- `worker.rs` — stopping while process-list-paused left the title stuck on "Paused". Clear it on stop.

## Related issue(s)

N/A

## Change type

- [x] Bug fix

## Screenshots (if applicable)

—

## Validation

`cargo fmt/clippy/test` (73/73) and `npm lint/tsc/test` (9/9) — all passed. My lines Prettier-clean.

## Checklist

- [x] I ran `npm run check:all` and it passed with no errors
- [x] I kept the change focused and avoided unrelated refactors
- [x] I updated related documentation when needed
