### PR TITLE
Fix hotkey fallback, speed up the picker hook, and remove dead code

### DIFF
--- a/src-tauri/src/hotkeys.rs
+++ b/src-tauri/src/hotkeys.rs
@@ -386,8 +386,12 @@ pub fn start_hotkey_listener(app: AppHandle) {
                 }
 
                 was_pressed = currently_pressed;
-            } else if PeekMessageW(&mut msg, std::ptr::null_mut(), 0, 0, PM_NOREMOVE) == 0 {
-                WaitMessage();
+            } else if HOOKS_ACTIVE.load(Ordering::Relaxed) {
+                if PeekMessageW(&mut msg, std::ptr::null_mut(), 0, 0, PM_NOREMOVE) == 0 {
+                    WaitMessage();
+                }
+            } else {
+                std::thread::sleep(POLL_INTERVAL);
             }
         }
 

--- a/src-tauri/src/sequence_picker.rs
+++ b/src-tauri/src/sequence_picker.rs
@@ -226,13 +226,14 @@ unsafe extern "system" fn mouse_hook_proc(code: i32, wparam: WPARAM, lparam: LPA
 
     let message = wparam as u32;
     let mouse = &*(lparam as *const MSLLHOOKSTRUCT);
-    let shift_down = (GetAsyncKeyState(VK_SHIFT as i32) & 0x8000u16 as i16) != 0;
-    let ctrl_down = (GetAsyncKeyState(VK_CONTROL as i32) & 0x8000u16 as i16) != 0;
 
     if message == WM_MOUSEMOVE {
         emit_cursor_position(mouse.pt.x, mouse.pt.y);
         return CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam);
     }
+
+    let shift_down = (GetAsyncKeyState(VK_SHIFT as i32) & 0x8000u16 as i16) != 0;
+    let ctrl_down = (GetAsyncKeyState(VK_CONTROL as i32) & 0x8000u16 as i16) != 0;
 
     match classify_mouse_message(message, shift_down, ctrl_down) {
         MouseHookDecision::Pass => CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam),

--- a/src/cadence.ts
+++ b/src/cadence.ts
@@ -146,22 +146,3 @@ export function getEffectiveClicksPerSecond(settings: CadenceSettings): number {
 export function isDoubleClickSupported(settings: CadenceSettings): boolean {
   return getEffectiveClicksPerSecond(settings) < 50;
 }
-
-export function formatDurationSummary(settings: CadenceSettings): string {
-  const parts: string[] = [];
-
-  if (settings.durationHours > 0) {
-    parts.push(`${settings.durationHours}h`);
-  }
-  if (settings.durationMinutes > 0) {
-    parts.push(`${settings.durationMinutes}m`);
-  }
-  if (settings.durationSeconds > 0) {
-    parts.push(`${settings.durationSeconds}s`);
-  }
-  if (settings.durationMilliseconds > 0 || parts.length === 0) {
-    parts.push(`${settings.durationMilliseconds}ms`);
-  }
-
-  return parts.join(" ");
-}

--- a/src/settingsSchema.ts
+++ b/src/settingsSchema.ts
@@ -375,11 +375,6 @@ const SETTINGS_ONLY_FIELDS = {
   },
 } satisfies Record<string, FieldDef<unknown>>;
 
-export const SETTINGS_FIELD_DEFS = {
-  ...PRESET_FIELDS,
-  ...SETTINGS_ONLY_FIELDS,
-};
-
 type DefaultValues<F extends Record<string, FieldDef<unknown>>> = {
   [K in keyof F]: F[K]["default"];
 };
@@ -450,35 +445,6 @@ export const SETTINGS_LIMITS = {
   stopZoneDimension: SETTINGS_ONLY_FIELDS.customStopZoneWidth.limit,
   sequencePointClicks: { min: 1, max: 100000 },
 };
-
-export const SETTINGS_UI_SCHEMA = [
-  {
-    id: "behavior",
-    fields: [
-      "alwaysOnTop",
-      "showStopOverlay",
-      "showStopReason",
-      "strictHotkeyModifiers",
-      "taskSwitcherStopEnabled",
-      "extendedClickSpeedLimit",
-    ],
-  },
-  {
-    id: "startup",
-    fields: ["minimizeToTray"],
-  },
-  {
-    id: "appearance",
-    fields: ["theme", "advancedSequenceLayout", "accentColor"],
-  },
-  {
-    id: "presets",
-    fields: ["presets", "activePresetId"],
-  },
-] as const satisfies ReadonlyArray<{
-  id: string;
-  fields: ReadonlyArray<keyof Settings>;
-}>;
 
 export function clampNumber(
   value: unknown,
@@ -673,16 +639,6 @@ export function buildPresetSnapshot(settings: Settings): PresetSnapshot {
   }
 
   return snapshot as PresetSnapshot;
-}
-
-export function applyPresetSnapshot(
-  base: Settings,
-  snapshot: PresetSnapshot,
-): Settings {
-  return {
-    ...base,
-    ...snapshot,
-  };
 }
 
 export function createPresetDefinition(


### PR DESCRIPTION
## Summary

Three follow-up improvements found in a cleanup pass:

- **`hotkeys.rs`** (bug) — if the global low-level hooks fail to install, the listener blocked forever on `WaitMessage()` and hotkeys stopped working completely, even though there's a polling fallback meant for exactly that case. Now it falls back to polling so hotkeys keep working.
- **`sequence_picker.rs`** (perf) — the mouse hook read two modifier keys on every event, including mouse-move (by far the most frequent). Moved those reads below the mouse-move early-return, so a move no longer makes two extra syscalls.
- **`cadence.ts` / `settingsSchema.ts`** (cleanup) — removed four exported functions/constants that nothing in the codebase uses (one was also stale).

## Related issue(s)

N/A

## Change type

- [x] Bug fix
- [ ] Documentation
- [ ] Contributor workflow / CI
- [x] Refactor
- [ ] Other

## Screenshots (if applicable)

—

## Validation

`cargo fmt --check`, `cargo clippy`, `cargo test` (73/73), `npm run lint`, `npx tsc -b`, `npm test` (9/9) — all passed.

## Checklist

- [x] I ran `npm run check:all` and it passed with no errors
- [x] I kept the change focused and avoided unrelated refactors
- [x] I updated related documentation when needed
